### PR TITLE
Code quality fix - Literal boolean values should not be used in condition expressions.

### DIFF
--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/http/resources/RvdController.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/http/resources/RvdController.java
@@ -94,7 +94,7 @@ public class RvdController extends RestService {
             // logging rcml response, if configured
             // make sure logging is enabled before allowing access to sensitive log information
             ProjectSettings projectSettings = rvdContext.getProjectSettings();
-            if (projectSettings.getLogging() == true && (projectSettings.getLoggingRCML() != null && projectSettings.getLoggingRCML() == true) ){
+            if (projectSettings.getLogging() && (projectSettings.getLoggingRCML() != null && projectSettings.getLoggingRCML()) ){
                 interpreter.getProjectLogger().log( rcmlResponse, false).tag("app", appname).tag("RCML").done();
             }
 
@@ -367,7 +367,7 @@ public class RvdController extends RestService {
 
             // make sure logging is enabled before allowing access to sensitive log information
             ProjectSettings projectSettings = FsProjectStorage.loadProjectSettings(appName, workspaceStorage);
-            if (projectSettings == null || projectSettings.getLogging() == false)
+            if (projectSettings == null || !projectSettings.getLogging())
                 return Response.status(Status.NOT_FOUND).build();
 
             InputStream logStream;
@@ -400,7 +400,7 @@ public class RvdController extends RestService {
 
             // make sure logging is enabled before allowing access to sensitive log information
             ProjectSettings projectSettings = FsProjectStorage.loadProjectSettings(appName, workspaceStorage);
-            if (projectSettings == null || projectSettings.getLogging() == false)
+            if (projectSettings == null || !projectSettings.getLogging())
                 return Response.status(Status.NOT_FOUND).build();
 
             rvdContext.getProjectLogger().reset();

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/utils/RvdUtils.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/utils/RvdUtils.java
@@ -44,7 +44,7 @@ public class RvdUtils {
 
     // returns True when either the value is True OR null
     public static boolean isEmpty( Boolean value) {
-        if ( value == null || value == false )
+        if ( value == null || !value )
             return true;
         return false;
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1125 - Literal boolean values should not be used in condition expressions. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1125

Please let me know if you have any questions.

Faisal Hameed