### PR TITLE
Code quality fix - Primitives should not be boxed just for "String" conversion.

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/VoiceInterpreter.java
@@ -1009,7 +1009,7 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
                         || (statusCode >= 200 && statusCode < 300 && "BYE".equalsIgnoreCase(method))) {
                     final String sipCallId = lastResponse.getCallId();
                     parameters.add(new BasicNameValuePair("DialSipCallId", sipCallId));
-                    parameters.add(new BasicNameValuePair("DialSipResponseCode", "" + statusCode));
+                    parameters.add(new BasicNameValuePair("DialSipResponseCode", Integer.toString(statusCode)));
                     processCustomHeaders(lastResponse, "DialSipHeader_", parameters);
                 }
             }

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/security/TicketRepository.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/security/TicketRepository.java
@@ -65,7 +65,7 @@ public class TicketRepository {
             logger.debug("Removing stale RVD tickets at " + currentDate);
             lastRemovalCheckTime = currentDate; // reset interval
             int removedCount = runStaleTicketRemovalJob(currentDate);
-            logger.debug("" + removedCount + " tickets removed." + tickets.size() + " tickets still in TicketRepository");
+            logger.debug(Integer.toString(removedCount) + " tickets removed." + tickets.size() + " tickets still in TicketRepository");
         }
 
     }

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/upgrade/UpgradeService.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/upgrade/UpgradeService.java
@@ -171,9 +171,9 @@ public class UpgradeService {
             }
         }
         if ( failedCount > 0 )
-            logger.info("" + failedCount + " RVD projects failed upgrade");
+            logger.info(Integer.toString(failedCount) + " RVD projects failed upgrade");
         if ( upgradedCount > 0 )
-            logger.info("" + upgradedCount + " RVD projects upgraded");
+            logger.info(Integer.toString(upgradedCount) + " RVD projects upgraded");
         if ( projectNames.size() > 0 && failedCount == 0)
             logger.info("--- All RVD projects are up to date");
         //if ( upgradedCount  0 && projectNames.size() > 0 )

--- a/restcomm/restcomm.ussd/src/main/java/org/mobicents/servlet/restcomm/ussd/interpreter/UssdInterpreter.java
+++ b/restcomm/restcomm.ussd/src/main/java/org/mobicents/servlet/restcomm/ussd/interpreter/UssdInterpreter.java
@@ -364,7 +364,7 @@ public class UssdInterpreter extends UntypedActor {
                         || (statusCode >= 200 && statusCode < 300 && "BYE".equalsIgnoreCase(method))) {
                     final String sipCallId = lastResponse.getCallId();
                     parameters.add(new BasicNameValuePair("DialSipCallId", sipCallId));
-                    parameters.add(new BasicNameValuePair("DialSipResponseCode", "" + statusCode));
+                    parameters.add(new BasicNameValuePair("DialSipResponseCode", Integer.toString(statusCode)));
                     Iterator<String> headerIt = lastResponse.getHeaderNames();
                     while (headerIt.hasNext()) {
                         String headerName = headerIt.next();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2131- Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2131

Please let me know if you have any questions.

Faisal Hameed