### PR TITLE
Code quality fix - Useless parentheses around expressions should be removed to prevent any misunderstanding.

### DIFF
--- a/restcomm/restcomm.http/src/main/java/org/mobicents/servlet/restcomm/http/client/Downloader.java
+++ b/restcomm/restcomm.http/src/main/java/org/mobicents/servlet/restcomm/http/client/Downloader.java
@@ -109,7 +109,7 @@ public final class Downloader extends UntypedActor {
     }
 
     private boolean isHttpError(final int code) {
-        return (code >= 400);
+        return code >= 400;
     }
 
     private HttpResponseDescriptor validateXML (final HttpResponseDescriptor descriptor) throws XMLStreamException {

--- a/restcomm/restcomm.http/src/main/java/org/mobicents/servlet/restcomm/http/converter/CallDetailRecordListConverter.java
+++ b/restcomm/restcomm.http/src/main/java/org/mobicents/servlet/restcomm/http/converter/CallDetailRecordListConverter.java
@@ -124,7 +124,7 @@ public final class CallDetailRecordListConverter extends AbstractConverter imple
     }
 
     private String getPreviousPageUri() {
-        return ((page == 0) ? "null" : pathUri + "?Page=" + (page - 1) + "&PageSize=" + pageSize);
+        return (page == 0) ? "null" : pathUri + "?Page=" + (page - 1) + "&PageSize=" + pageSize;
     }
 
     private String getNextPageUri(CallDetailRecordList list) {

--- a/restcomm/restcomm.mscontrol.api/src/main/java/org/mobicents/servlet/restcomm/mscontrol/messages/Collect.java
+++ b/restcomm/restcomm.mscontrol.api/src/main/java/org/mobicents/servlet/restcomm/mscontrol/messages/Collect.java
@@ -50,7 +50,7 @@ public final class Collect {
     }
 
     public boolean hasPrompts() {
-        return (prompts != null && !prompts.isEmpty());
+        return prompts != null && !prompts.isEmpty();
     }
 
     public String pattern() {
@@ -58,7 +58,7 @@ public final class Collect {
     }
 
     public boolean hasPattern() {
-        return (pattern != null && !pattern.isEmpty());
+        return pattern != null && !pattern.isEmpty();
     }
 
     public int timeout() {
@@ -70,7 +70,7 @@ public final class Collect {
     }
 
     public boolean hasEndInputKey() {
-        return (endInputKey != null && !endInputKey.isEmpty());
+        return endInputKey != null && !endInputKey.isEmpty();
     }
 
     public int numberOfDigits() {

--- a/restcomm/restcomm.mscontrol.api/src/main/java/org/mobicents/servlet/restcomm/mscontrol/messages/Record.java
+++ b/restcomm/restcomm.mscontrol.api/src/main/java/org/mobicents/servlet/restcomm/mscontrol/messages/Record.java
@@ -65,7 +65,7 @@ public final class Record {
     }
 
     public boolean hasPrompts() {
-        return (prompts != null && !prompts.isEmpty());
+        return prompts != null && !prompts.isEmpty();
     }
 
     public int timeout() {
@@ -81,6 +81,6 @@ public final class Record {
     }
 
     public boolean hasEndInputKey() {
-        return (endInputKey != null && !endInputKey.isEmpty());
+        return endInputKey != null && !endInputKey.isEmpty();
     }
 }

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/model/steps/dial/DialStep.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/model/steps/dial/DialStep.java
@@ -43,7 +43,7 @@ public class DialStep extends Step {
         }
 
         rcmlStep.timeout = timeout == null ? null : timeout.toString();
-        rcmlStep.timeLimit = (timeLimit == null ? null : timeLimit.toString());
+        rcmlStep.timeLimit = timeLimit == null ? null : timeLimit.toString();
         rcmlStep.callerId = interpreter.populateVariables(callerId);
         rcmlStep.record = record;
 

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/utils/RvdUtils.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/utils/RvdUtils.java
@@ -50,7 +50,7 @@ public class RvdUtils {
     }
 
     public static boolean safeEquals(String value1, String value2) {
-        return value1 == null ? (value1 == value2) : (value1.equals(value2));
+        return value1 == null ? (value1 == value2) : value1.equals(value2);
     }
 
     /**

--- a/restcomm/restcomm.telephony.api/src/main/java/org/mobicents/servlet/restcomm/telephony/util/B2BUAHelper.java
+++ b/restcomm/restcomm.telephony.api/src/main/java/org/mobicents/servlet/restcomm/telephony/util/B2BUAHelper.java
@@ -540,7 +540,7 @@
       */
      public static boolean isB2BUASession(SipServletMessage sipMessage) {
          SipSession linkedB2BUASession = getLinkedSession(sipMessage);
-         return (linkedB2BUASession != null);
+         return linkedB2BUASession != null;
      }
 
  }

--- a/restcomm/restcomm.telephony/src/main/java/org/mobicents/servlet/restcomm/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/mobicents/servlet/restcomm/telephony/Call.java
@@ -531,7 +531,7 @@ public final class Call extends UntypedActor {
                     builder.setTo(to.getUser());
                     builder.setCallerName(name);
                     builder.setStartTime(new DateTime());
-                    String fromString = (from.getUser() != null ? from.getUser() : "CALLS REST API");
+                    String fromString = from.getUser() != null ? from.getUser() : "CALLS REST API";
                     builder.setFrom(fromString);
                     // builder.setForwardedFrom(callInfo.forwardedFrom());
                     // builder.setPhoneNumberSid(phoneId);

--- a/restcomm/restcomm.telephony/src/main/java/org/mobicents/servlet/restcomm/telephony/CallManager.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/mobicents/servlet/restcomm/telephony/CallManager.java
@@ -564,7 +564,7 @@ public final class CallManager extends UntypedActor {
     private boolean redirectToClientVoiceApp(final ActorRef self, final SipServletRequest request, final AccountsDao accounts,
             final ApplicationsDao applications, final Client client) {
         URI clientAppVoiceUril = client.getVoiceUrl();
-        boolean isClientManaged = (clientAppVoiceUril != null);
+        boolean isClientManaged = clientAppVoiceUril != null;
         if (isClientManaged) {
             final VoiceInterpreterBuilder builder = new VoiceInterpreterBuilder(system);
             builder.setConfiguration(configuration);

--- a/restcomm/restcomm.ussd/src/main/java/org/mobicents/servlet/restcomm/ussd/interpreter/UssdInterpreter.java
+++ b/restcomm/restcomm.ussd/src/main/java/org/mobicents/servlet/restcomm/ussd/interpreter/UssdInterpreter.java
@@ -335,9 +335,9 @@ public class UssdInterpreter extends UntypedActor {
         parameters.add(new BasicNameValuePair("CallSid", callSid));
         final String accountSid = accountId.toString();
         parameters.add(new BasicNameValuePair("AccountSid", accountSid));
-        final String from = (callInfo.from());
+        final String from = callInfo.from();
         parameters.add(new BasicNameValuePair("From", from));
-        final String to = (callInfo.to());
+        final String to = callInfo.to();
         parameters.add(new BasicNameValuePair("To", to));
         final String state = callState.toString();
         parameters.add(new BasicNameValuePair("CallStatus", state));


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.

Faisal Hameed