### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/restcomm/restcomm.commons/src/main/java/org/mobicents/servlet/restcomm/amazonS3/S3AccessTool.java
+++ b/restcomm/restcomm.commons/src/main/java/org/mobicents/servlet/restcomm/amazonS3/S3AccessTool.java
@@ -80,7 +80,7 @@ public class S3AccessTool {
         s3client.setRegion(Region.getRegion(Regions.fromName(bucketRegion)));
         logger.info("S3 Region: "+bucketRegion.toString());
         try {
-            StringBuffer bucket = new StringBuffer();
+            StringBuilder bucket = new StringBuilder();
             bucket.append(bucketName);
             if (folder != null && !folder.isEmpty())
                 bucket.append("/").append(folder);

--- a/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/BaseVoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/BaseVoiceInterpreter.java
@@ -244,7 +244,7 @@ public abstract class BaseVoiceInterpreter extends UntypedActor {
     Boolean dtmfReceived = false;
     String finishOnKey;
     int numberOfDigits = Short.MAX_VALUE;
-    StringBuffer collectedDigits;
+    StringBuilder collectedDigits;
     //Monitoring service
     ActorRef monitoring;
 
@@ -1485,7 +1485,7 @@ public abstract class BaseVoiceInterpreter extends UntypedActor {
             gatherChildren = null;
             gatherPrompts = null;
             dtmfReceived = false;
-            collectedDigits = new StringBuffer("");
+            collectedDigits = new StringBuilder("");
         }
     }
 
@@ -1500,7 +1500,7 @@ public abstract class BaseVoiceInterpreter extends UntypedActor {
             final NotificationsDao notifications = storage.getNotificationsDao();
             Attribute attribute = verb.attribute("action");
             String digits = collectedDigits.toString();
-            collectedDigits = new StringBuffer();
+            collectedDigits = new StringBuilder();
             logger.info("Digits collected: "+digits);
             if (digits.equals(finishOnKey)) {
                 digits = "";

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/ProjectLogger.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/ProjectLogger.java
@@ -84,7 +84,7 @@ public class ProjectLogger {
 
     public void done() {
         Date date = new Date();
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         buffer.append("[" + date.toString() + "]");
         for ( String tag : tags ) {
             if (tag == null)

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/http/RestService.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/http/RestService.java
@@ -78,7 +78,7 @@ public class RestService {
     }
 
     protected Response buildWebTriggerHtmlResponse(String title, String action, String outcome, String description, Integer status ) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         buffer.append("<html><body>");
         if (title != null)
             buffer.append("<h1>").append(title).append("</h1>");

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/interpreter/Interpreter.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/interpreter/Interpreter.java
@@ -450,7 +450,7 @@ public class Interpreter {
         // System.out.printf( "found variable %s at %d\n", v.variableName, v.position );
         // }
 
-        StringBuffer buffer = new StringBuffer(sourceText);
+        StringBuilder buffer = new StringBuilder(sourceText);
         Collections.reverse(variablesInText);
         for (VariableInText v : variablesInText) {
             String replaceValue = "";

--- a/restcomm/restcomm.telephony/src/main/java/org/mobicents/servlet/restcomm/telephony/ua/UserAgentManager.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/mobicents/servlet/restcomm/telephony/ua/UserAgentManager.java
@@ -311,7 +311,7 @@ public final class UserAgentManager extends UntypedActor {
             patch(uri, ip, port);
         }
 
-        final StringBuffer buffer = new StringBuffer();
+        final StringBuilder buffer = new StringBuilder();
         buffer.append("sip:").append(user).append("@").append(uri.getHost()).append(":").append(uri.getPort());
         // https://bitbucket.org/telestax/telscale-restcomm/issue/142/restcomm-support-for-other-transports-than
         if (transport != null) {

--- a/restcomm/restcomm.ussd/src/main/java/org/mobicents/servlet/restcomm/ussd/interpreter/UssdInterpreter.java
+++ b/restcomm/restcomm.ussd/src/main/java/org/mobicents/servlet/restcomm/ussd/interpreter/UssdInterpreter.java
@@ -763,7 +763,7 @@ public class UssdInterpreter extends UntypedActor {
                     ussdRestcommResponse.setMessageLength(nonEnglishLength);
                 }
 
-                StringBuffer ussdText = processUssdMessageTags(ussdMessageTags);
+                StringBuilder ussdText = processUssdMessageTags(ussdMessageTags);
 
                 if (ussdCollectTag != null) {
                     hasCollect = true;
@@ -787,7 +787,7 @@ public class UssdInterpreter extends UntypedActor {
                         sendMail(notification);
                     }
                     logger.info(errorString);
-                    ussdText = new StringBuffer();
+                    ussdText = new StringBuilder();
                     ussdText.append("Error while preparing the response.\nMessage length exceeds the maximum.");
                 }
 
@@ -825,8 +825,8 @@ public class UssdInterpreter extends UntypedActor {
         }
     }
 
-    private StringBuffer processUssdMessageTags(Queue<Tag> messageTags) {
-        StringBuffer message = new StringBuffer();
+    private StringBuilder processUssdMessageTags(Queue<Tag> messageTags) {
+        StringBuilder message = new StringBuilder();
         while (!messageTags.isEmpty()) {
             Tag tag = messageTags.poll();
             if (tag != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed