### PR TITLE
Issue1028_FixRVDUpgrade

### DIFF
--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/scripts/mariadb/sql/applications.xml
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/scripts/mariadb/sql/applications.xml
@@ -16,7 +16,7 @@
   </select>
 
   <select id="getApplicationByFriendlyName" parameterType="string" resultType="hashmap">
-    SELECT * FROM restcomm_applications WHERE friendly_name=#{friendly_name};
+    SELECT * FROM restcomm_applications WHERE BINARY friendly_name=#{friendly_name};
   </select>
   
   <select id="getApplications" parameterType="string" resultType="hashmap">

--- a/restcomm/restcomm.http/src/main/java/org/mobicents/servlet/restcomm/http/ApplicationsEndpoint.java
+++ b/restcomm/restcomm.http/src/main/java/org/mobicents/servlet/restcomm/http/ApplicationsEndpoint.java
@@ -199,9 +199,9 @@ public class ApplicationsEndpoint extends AbstractEndpoint {
         if (application == null) {
             application = createFrom(new Sid(accountSid), data);
             dao.addApplication(application);
-        } else if (!application.getAccountSid().toString().equals(account.getSid().toString())) {
-            return status(CONFLICT)
-                    .entity("A application with the same name was already created by another account. Please, choose a different name and try again.")
+        } else {
+            return status(CONFLICT).entity(
+                    "A application with the same name was already created. Please, choose a different name and try again.")
                     .build();
         }
 


### PR DESCRIPTION
This PR contains fixes for two different problems.

- **Problem 1**: RVD Workspace Migration uses wrong Application entity to synchronise RVD projects, like described in detail by Issue #1028;

- **Problem 2**: Create a new RVD Project present a unstable behaviour if the project name was already used before by another Application of the same user Account, like described in detail by Issue #1036.

-----------------

- Fix for **Problem 1**: affects only the `applications.xml` file and may does not require a new build of the whole project (since a text file), this may handy to manually apply the fix inside the environments without the need of a upgrade;

- Fix for **Problem 2**: affects file `ApplicationsEndpoint.java` and depends on `applications.xml` to work properly, so may its better to trust this into a new build/compilation of RestComm.

This way, considering the PR #1027 which is able to fix one RVD Workspace Migration issue using a SQL script, it may be possible to consider also the Fix for **Problem 1** described here as one patch to fix the urgent issues without a new build of RestComm applying it manually (once they are text files), and later provide a new build with everything in place.