### PR TITLE
SIP diversion header available in RVD

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/mobicents/servlet/restcomm/interpreter/VoiceInterpreter.java
@@ -1137,7 +1137,7 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
                     final String sipCallId = lastResponse.getCallId();
                     parameters.add(new BasicNameValuePair("DialSipCallId", sipCallId));
                     parameters.add(new BasicNameValuePair("DialSipResponseCode", "" + statusCode));
-                    processCustomHeaders(lastResponse, "DialSipHeader_", parameters);
+                    processCustomAndDiversionHeaders(lastResponse, "DialSipHeader_", parameters);
                 }
             }
         }
@@ -1147,24 +1147,53 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
             // https://telestax.atlassian.net/browse/RESTCOMM-710
             final SipServletRequest invite = callInfo.invite();
             // For outbound calls created with Calls REST API, the invite at this point will be null
-            if (invite != null)
-                processCustomHeaders(invite, "SipHeader_", parameters);
+            if (invite != null) {
+                processCustomAndDiversionHeaders(invite, "SipHeader_", parameters);
+
+            }
         } else {
-            processCustomHeaders(lastResponse, "SipHeader_", parameters);
+            processCustomAndDiversionHeaders(lastResponse, "SipHeader_", parameters);
         }
 
         return parameters;
     }
 
-    private void processCustomHeaders(SipServletMessage sipMessage, String prefix, List<NameValuePair> parameters) {
+    private void processCustomAndDiversionHeaders(SipServletMessage sipMessage, String prefix, List<NameValuePair> parameters) {
         Iterator<String> headerNames = sipMessage.getHeaderNames();
         while (headerNames.hasNext()) {
             String headerName = headerNames.next();
             if (headerName.startsWith("X-")) {
-                if(logger.isDebugEnabled()) {
-                    logger.debug("%%%%%%%%%%% Indetified customer header: " + headerName);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("%%%%%%%%%%% Identified customer header: " + headerName);
                 }
                 parameters.add(new BasicNameValuePair(prefix + headerName, sipMessage.getHeader(headerName)));
+            } else if (headerName.startsWith("Diversion")) {
+
+                final String sipDiversionHeader = sipMessage.getHeader(headerName);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("%%%%%%%%%%% Identified diversion header: " + sipDiversionHeader);
+                }
+                parameters.add(new BasicNameValuePair(prefix + headerName, sipDiversionHeader));
+
+                try {
+                    final String forwardedFrom = sipDiversionHeader.substring(sipDiversionHeader.indexOf("sip:") + 4,
+                            sipDiversionHeader.indexOf("@"));
+
+                    for(int i=0; i < parameters.size(); i++) {
+                        if (parameters.get(i).getName().equals("ForwardedFrom")) {
+                            if (parameters.get(i).getValue().equals("null")) {
+                                parameters.remove(i);
+                                parameters.add(new BasicNameValuePair("ForwardedFrom", forwardedFrom));
+                                break;
+                            } else {
+                                // Not null, so it's not going to be overwritten with Diversion Header
+                                break;
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.warning("Error parsing SIP Diversion header"+ e.getMessage());
+                }
             }
         }
     }

--- a/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/RvdConfiguration.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/mobicents/servlet/restcomm/rvd/RvdConfiguration.java
@@ -39,11 +39,15 @@ public class RvdConfiguration {
     public static final String PACKAGING_DIRECTORY_NAME = "packaging";
     public static final String TICKET_COOKIE_NAME = "rvdticket"; // the name of the cookie that is used to store ticket ids for authentication
     // the names of the parameters supplied by restcomm request when starting an application
-    private static Set<String> restcommParameterNames  = new HashSet<String>(Arrays.asList(new String[] {"CallSid","AccountSid","From","To","Body","CallStatus","ApiVersion","Direction","CallerName","CallTimestamp"}));
+    private static Set<String> restcommParameterNames  = new HashSet<String>(Arrays.asList(new String[] {"CallSid",
+            "AccountSid","From","To","Body","CallStatus","ApiVersion","Direction","CallerName","CallTimestamp",
+            "ForwardedFrom"}));
     public static final String PROJECT_LOG_FILENAME = "projectLog";
     public static final String DEFAULT_APPSTORE_DOMAIN = "apps.restcomm.com";
     // TODO investigate duplicate static parameters restcommParameterNames VS builtinRestcommParameters
-    public static final HashSet<String> builtinRestcommParameters = new HashSet<String>(Arrays.asList(new String[] {"CallSid","AccountSid","From","To","Body","CallStatus","ApiVersion","Direction","CallerName","CallTimestamp"}));
+    public static final HashSet<String> builtinRestcommParameters = new HashSet<String>(Arrays.asList(new String[]
+            {"CallSid","AccountSid","From","To","Body","CallStatus","ApiVersion","Direction","CallerName",
+                    "CallTimestamp", "ForwardedFrom"}));
     public static final String RESTCOMM_HEADER_PREFIX = "SipHeader_"; // the prefix added to HTTP headers from Restcomm
     public static final String RESTCOMM_HEADER_PREFIX_DIAL = "DialSipHeader_"; // another prefix
 

--- a/restcomm/restcomm.rvd/src/main/webapp/js/app/services.js
+++ b/restcomm/restcomm.rvd/src/main/webapp/js/app/services.js
@@ -549,6 +549,7 @@ angular.module('Rvd').service('variableRegistry', [function () {
 	registerVariable("core_Direction");
 	registerVariable("core_CallerName");
     registerVariable("core_CallTimestamp");
+    registerVariable("core_ForwardedFrom");
 	// after collect, record, ussdcollect
 	registerVariable("core_Digits");
 	// after dial


### PR DESCRIPTION
It allows to have the value of SIP DIversion Header in a new RVD variable named $core_diversion. Also, it publish the variable $core_ForwardedFrom with the number so it may be used (only if the variable is empty).

We have tested with Voxbone, returning the following values:

- $core_diversion: \u003csip:YYXXXXXXXXX@voxbone.com\u003e;counter\u003d1;reason\u003dUSER-BUSY"
- $core_ForwardedFrom: YYXXXXXXXXX

A sipp scenario I've used to test it: https://gist.github.com/antonmry/cbb9383e4199fe294cbcb01d6ba1e573