### PR TITLE
Update config-restcomm.sh

### DIFF
--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
@@ -506,7 +506,7 @@ otherRestCommConf(){
     mv $FILE.bak $FILE
 
     echo "CACHE_NO_WAV $CACHE_NO_WAV"
-    sed -i "s|<cache-no-wav>.*</cache-no-wav>|<cache-no-wav>${CACHE_NO_WAV}</cache-no-wav|" $FILE
+    sed -i "s|<cache-no-wav>.*</cache-no-wav>|<cache-no-wav>${CACHE_NO_WAV}</cache-no-wav>|" $FILE
 
     echo "End Rest RestComm configuration"
 }


### PR DESCRIPTION
The end-tag for element type "cache-no-wav" must end with a '>' delimiter.