### PR TITLE
Issue1596 review application access rules and optimize account closing

### DIFF
--- a/restcomm/restcomm.http/src/main/java/org/restcomm/connect/http/SecuredEndpoint.java
+++ b/restcomm/restcomm.http/src/main/java/org/restcomm/connect/http/SecuredEndpoint.java
@@ -313,7 +313,12 @@ public abstract class SecuredEndpoint extends AbstractEndpoint {
         return AuthOutcome.FAILED;
     }
 
-    /** Applies the following access control rules
+    /**
+     * Uses the security policy applied by secureLevelControl(). See there for details.
+     *
+     * DEPRECATED security policy:
+     *
+     * Applies the following access control rules
      *
      * If an application Account Sid is given:
      *  - If operatingAccount is the same as the operated account and application resource belongs to operated account too
@@ -328,6 +333,9 @@ public abstract class SecuredEndpoint extends AbstractEndpoint {
      * @return
      */
     private AuthOutcome secureLevelControlApplications(Account operatedAccount, String applicationAccountSid) {
+        /*
+        // disabled strict policy that prevented access to sub-account applications
+
         // operatingAccount and operatedAccount are not null at this point
         Account operatingAccount = userIdentityContext.getEffectiveAccount();
         String operatingAccountSid = operatingAccount.getSid().toString();
@@ -338,6 +346,10 @@ public abstract class SecuredEndpoint extends AbstractEndpoint {
             return AuthOutcome.FAILED;
         }
         return AuthOutcome.OK;
+        */
+
+        // use the more liberal default policy that applies to other entities for applications too
+        return secureLevelControl(operatedAccount, applicationAccountSid);
     }
 
     /** Applies the following access control rules:

--- a/restcomm/restcomm.rvd/src/main/java/org/restcomm/connect/rvd/restcomm/RestcommApplicationsResponse.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/restcomm/connect/rvd/restcomm/RestcommApplicationsResponse.java
@@ -1,0 +1,29 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2014, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+package org.restcomm.connect.rvd.restcomm;
+
+import java.util.ArrayList;
+
+/**
+ * @author otsakir@gmail.com - Orestis Tsakiridis
+ */
+public class RestcommApplicationsResponse extends ArrayList<RestcommApplicationResponse> {
+}

--- a/restcomm/restcomm.rvd/src/main/java/org/restcomm/connect/rvd/restcomm/RestcommClient.java
+++ b/restcomm/restcomm.rvd/src/main/java/org/restcomm/connect/rvd/restcomm/RestcommClient.java
@@ -225,14 +225,14 @@ public class RestcommClient {
     }
 
     /**
-     * @param fallbackRestcommBaseUri
+     * @param restcommBaseUri
      * @throws RestcommClientInitializationException
      */
-    public RestcommClient (URI fallbackRestcommBaseUri, String authHeader, CustomHttpClientBuilder httpClientbuilder) throws RestcommClientInitializationException {
+    public RestcommClient (URI restcommBaseUri, String authHeader, CustomHttpClientBuilder httpClientbuilder) throws RestcommClientInitializationException {
         if (RvdUtils.isEmpty(authHeader))
             throw new RestcommClientInitializationException("Restcomm client could not determine the user for accessing Restcomm");
         this.authHeader = authHeader;
-        this.restcommBaseUrl = fallbackRestcommBaseUri;
+        this.restcommBaseUrl = restcommBaseUri;
         apacheClient = httpClientbuilder.buildHttpClient();
     }
 

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/http/AccountsEndpointClosingTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/http/AccountsEndpointClosingTest.java
@@ -88,10 +88,10 @@ public class AccountsEndpointClosingTest extends EndpointTest {
         ClientResponse response = resource.put(ClientResponse.class,params);
         Assert.assertEquals(200, response.getStatus());
         // wait until all asynchronous request have been sent to RVD
-        verify(postRequestedFor(urlMatching("/restcomm-rvd/services/notifications"))
+        verify(6, postRequestedFor(urlMatching("/restcomm-rvd/services/notifications"))
                 .withHeader("Content-Type", containing("application/json"))
-                .withRequestBody(equalToJson("[{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000005\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000004\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000003\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000002\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000001\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000000\"}]")
-                ));
+                //.withRequestBody(equalToJson("[{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000005\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000004\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000003\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000002\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000001\"},{\"type\":\"accountClosed\",\"accountSid\":\"ACA1000000000000000000000000000000\"}]")
+                );
     }
 
     // verify that DID provider (nexmo) was contacted to cancel the numbers when the account is removed

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/http/MultitenancyAllowAccessApiTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/http/MultitenancyAllowAccessApiTest.java
@@ -60,6 +60,7 @@ public class MultitenancyAllowAccessApiTest {
     @ArquillianResource
     URL deploymentUrl;
 
+    private final static String adminAccountSid = "ACae6e420f425248d6a26948c17a9e2acf";
     private final static String primaryUsername = "primary@company.com";
     private final static String primaryAccountSid = "AC1ec5d14c34a421c7697e1ce5d4eac782";
     private final static String subaccountaAccountSid = "AC5fa870789e95b7867a0fc0b85c5805e9";
@@ -266,6 +267,7 @@ public class MultitenancyAllowAccessApiTest {
 
     @Test
     public void applicationsApi() throws ClientProtocolException, IOException {
+        // access to account's own applications
         String baseUrl = deploymentUrl.toString() + apiPath + primaryAccountSid + "/Applications";
         int statusCode = RestcommMultitenancyTool.getInstance().get(baseUrl + jsonExtension, primaryUsername, accountsPassword);
         assertTrue(statusCode == httpOk);
@@ -275,10 +277,20 @@ public class MultitenancyAllowAccessApiTest {
         assertTrue(statusCode == httpOk);
         statusCode = RestcommMultitenancyTool.getInstance().post(baseUrl + "/" + primaryApplicationSid + jsonExtension, primaryUsername, accountsPassword, new HashMap<String,String>(){{ put("FriendlyName","TEST123"); }});
         assertTrue(statusCode == httpOk);
-        Map<String,String> updateParams = new HashMap<String,String>();
-        updateParams.put("Status", "closed");
-        statusCode = RestcommMultitenancyTool.getInstance().update(baseUrl + "/" + primaryApplicationSid + jsonExtension, primaryUsername, accountsPassword,updateParams);
+        // access to sub-account applications
+        // list
+        statusCode = RestcommMultitenancyTool.getInstance().get(baseUrl + jsonExtension, adminAccountSid, accountsPassword);
+        Assert.assertEquals(httpOk, statusCode);
+        // get single
+        statusCode = RestcommMultitenancyTool.getInstance().get(baseUrl + "/" + primaryApplicationSid + jsonExtension, adminAccountSid, accountsPassword);
         assertTrue(statusCode == httpOk);
+        // create
+        statusCode = RestcommMultitenancyTool.getInstance().post(baseUrl + jsonExtension, adminAccountSid, accountsPassword, new HashMap<String,String>(){{ put("FriendlyName","TEST"); }});
+        assertTrue(statusCode == httpOk);
+        // update
+        statusCode = RestcommMultitenancyTool.getInstance().post(baseUrl + "/" + primaryApplicationSid + jsonExtension, adminAccountSid, accountsPassword, new HashMap<String,String>(){{ put("FriendlyName","TEST123"); }});
+        assertTrue(statusCode == httpOk);
+
     }
 
     private Endpoint[] modifyPostParameters(String suffix) {


### PR DESCRIPTION
The patch does the following:
1. Relaxes application REST API access rules (allows parent accounts access sub-account applications) - #1596 
2. Reviews RVD notification mechanism for account removal from RVD side. RVD now queries Restcomm to get application for a specific (removed) account instead of going through all the project in the workspace
3. Refactors account closing so that it sends one notification per account removed instead of a single notification array. The reason is to reduce complexity in the account closing implementation.