### PR TITLE
fixed zendesk#34319

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
@@ -189,6 +189,7 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
     private ActorRef confSubVoiceInterpreter;
     private Attribute dialRecordAttribute;
     private boolean dialActionExecuted = false;
+    private boolean dialCompletedStatusCallBackExecuted = false;
     private ActorRef sender;
     private boolean liveCallModification = false;
     private boolean recordingCall = true;
@@ -2521,6 +2522,7 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
                         }
                         dialChildren = null;
                         callback();
+                        dialCompletedStatusCallBackExecuted = true;
                         return;
                     } else if (dialBranches != null && dialBranches.contains(sender)) {
                         if (logger.isInfoEnabled()) {
@@ -2995,6 +2997,11 @@ public final class VoiceInterpreter extends BaseVoiceInterpreter {
             if (!dialActionExecuted) {
                 executeDialAction(message, outboundCall);
                 callback(true);
+                dialCompletedStatusCallBackExecuted = true;
+            }
+
+            if (!dialCompletedStatusCallBackExecuted) {
+                callback();
             }
             // XXX review bridge cleanup!!
 

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/TestDialVerbPartTwo.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/TestDialVerbPartTwo.java
@@ -1484,6 +1484,155 @@ public class TestDialVerbPartTwo {
         assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
         assertEquals(Response.BUSY_HERE, bobCall.getLastReceivedResponse().getStatusCode());
     }
+    
+    private String dialClientWithActionRcml = "<Response><Dial action=\"http://127.0.0.1:8090/action\" method=\"GET\"><Client>alice</Client></Dial></Response>";
+    private String hangupActionRcml = "<Response><Hangup /></Response>";
+    
+    @Test // (customised from testDialClientAliceWithRecordAndStatusCallbackForApp)
+    public synchronized void testDialClientAliceWithActionAndStatusCallbackForApp() throws InterruptedException, ParseException {
+        stubFor(get(urlPathEqualTo("/1111"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(dialClientWithActionRcml)));
+
+        stubFor(get(urlPathEqualTo("/action"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(hangupActionRcml)));
+
+        stubFor(get(urlPathMatching("/StatusCallBack.*"))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        // Phone2 register as alice
+        SipURI uri = aliceSipStack.getAddressFactory().createSipURI(null, "127.0.0.1:5080");
+        assertTrue(alicePhone.register(uri, "alice", "1234", aliceContact, 3600, 3600));
+
+        // Prepare second phone to receive call
+        SipCall aliceCall = alicePhone.createSipCall();
+        aliceCall.listenForIncomingCall();
+
+        // Create outgoing call with first phone
+        final SipCall bobCall = bobPhone.createSipCall();
+        bobCall.initiateOutgoingCall(bobContact, dialRestcommWithStatusCallback, null, body, "application", "sdp", null, null);
+        assertLastOperationSuccess(bobCall);
+        assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+        final int response = bobCall.getLastReceivedResponse().getStatusCode();
+        assertTrue(response == Response.TRYING || response == Response.RINGING);
+
+        if (response == Response.TRYING) {
+            assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+            assertEquals(Response.RINGING, bobCall.getLastReceivedResponse().getStatusCode());
+        }
+
+        assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+        assertEquals(Response.OK, bobCall.getLastReceivedResponse().getStatusCode());
+
+        bobCall.sendInviteOkAck();
+        assertTrue(!(bobCall.getLastReceivedResponse().getStatusCode() >= 400));
+
+        assertTrue(aliceCall.waitForIncomingCall(3 * 1000));
+        assertTrue(aliceCall.sendIncomingCallResponse(Response.RINGING, "Ringing-Alice", 3600));
+        String receivedBody = new String(aliceCall.getLastReceivedRequest().getRawContent());
+        assertTrue(aliceCall.sendIncomingCallResponse(Response.OK, "OK-Alice", 3600, receivedBody, "application", "sdp", null,
+                null));
+        assertTrue(aliceCall.waitForAck(5 * 1000));
+
+        Thread.sleep(3000);
+
+        // hangup (must be as alice, the callee, hanging up in order to test the specific issue found)
+        
+        aliceCall.disconnect();
+        bobCall.listenForDisconnect();
+        assertTrue(bobCall.waitForDisconnect(3 * 1000));
+        assertTrue(bobCall.respondToDisconnect());
+
+        Thread.sleep(5000);
+
+        logger.info("About to check the Status Callback Requests");
+        List<LoggedRequest> requests = findAll(getRequestedFor(urlPathMatching("/StatusCallBack.*")));
+
+        for (LoggedRequest loggedRequest : requests) {
+            logger.info("Status callback received: " + loggedRequest.getUrl());
+        }
+        assertTrue(requests.size()==3);
+    }
+    
+    private String dialTimeOutClientWithActionRcml = "<Response><Dial timeout=\"3\" action=\"http://127.0.0.1:8090/action\" method=\"GET\"><Client>alice</Client></Dial></Response>";
+    
+    @Test // (customised from testDialClientAliceWithRecordAndStatusCallbackForApp)
+    public synchronized void testDialTimeOutClientAliceWithActionAndStatusCallbackForApp() throws InterruptedException, ParseException {
+        stubFor(get(urlPathEqualTo("/1111"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(dialTimeOutClientWithActionRcml)));
+
+        stubFor(get(urlPathEqualTo("/action"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(hangupActionRcml)));
+
+        stubFor(get(urlPathMatching("/StatusCallBack.*"))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        // Phone2 register as alice
+        SipURI uri = aliceSipStack.getAddressFactory().createSipURI(null, "127.0.0.1:5080");
+        assertTrue(alicePhone.register(uri, "alice", "1234", aliceContact, 3600, 3600));
+
+        // Prepare second phone to receive call
+        SipCall aliceCall = alicePhone.createSipCall();
+        aliceCall.listenForIncomingCall();
+
+        // Create outgoing call with first phone
+        final SipCall bobCall = bobPhone.createSipCall();
+        bobCall.initiateOutgoingCall(bobContact, dialRestcommWithStatusCallback, null, body, "application", "sdp", null, null);
+        assertLastOperationSuccess(bobCall);
+        assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+        final int response = bobCall.getLastReceivedResponse().getStatusCode();
+        assertTrue(response == Response.TRYING || response == Response.RINGING);
+
+        if (response == Response.TRYING) {
+            assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+            assertEquals(Response.RINGING, bobCall.getLastReceivedResponse().getStatusCode());
+        }
+
+        assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+        assertEquals(Response.OK, bobCall.getLastReceivedResponse().getStatusCode());
+
+        bobCall.sendInviteOkAck();
+        assertTrue(!(bobCall.getLastReceivedResponse().getStatusCode() >= 400));
+
+        assertTrue(aliceCall.waitForIncomingCall(3 * 1000));
+        assertTrue(aliceCall.sendIncomingCallResponse(Response.RINGING, "Ringing-Alice", 3600));
+        String receivedBody = new String(aliceCall.getLastReceivedRequest().getRawContent());
+
+        aliceCall.listenForCancel();
+
+        SipTransaction cancelTransaction = aliceCall.waitForCancel(100 * 1000);
+        assertNotNull(cancelTransaction);
+        assertTrue(aliceCall.respondToCancel(cancelTransaction, Response.OK, "Alice-OK-2-Cancel", 3600));
+
+        // hangup (must be as alice, the callee, hanging up in order to test the specific issue found)
+        
+        bobCall.listenForDisconnect();
+        assertTrue(bobCall.waitForDisconnect(3 * 1000));
+        assertTrue(bobCall.respondToDisconnect());
+
+        Thread.sleep(5000);
+
+        logger.info("About to check the Status Callback Requests");
+        List<LoggedRequest> requests = findAll(getRequestedFor(urlPathMatching("/StatusCallBack.*")));
+
+        for (LoggedRequest loggedRequest : requests) {
+            logger.info("Status callback received: " + loggedRequest.getUrl());
+        }
+        assertTrue(requests.size()==4);
+}
 
     @Deployment(name = "TestDialVerbPartTwo", managed = true, testable = false)
     public static WebArchive createWebArchiveNoGw() {


### PR DESCRIPTION
This is the fix for #1905 and also customer open zendesk ticket number #34319

Here is the CI result:
https://mobicents.ci.cloudbees.com/view/RestComm/job/RestComm-For-Specific-Branch/59/#showFailuresLink

Test Result (33 failures )
org.restcomm.connect.dao.mybatis.CallDetailRecordsDaoTest.testReadByEndTime
org.restcomm.connect.mgcp.LinkTest.testSuccessfulScenarioWithModify
org.restcomm.connect.mgcp.LinkTest.testSuccessfulScenario
org.restcomm.connect.testsuite.http.AccountsEndpointTest.testCreateAccountWithJapaneseChars
org.restcomm.connect.testsuite.http.CreateCallsTest.createCallNumberTest
org.restcomm.connect.testsuite.http.LiveCallModificationAnswerDelayTest.testTerminateDialForkCallWhileRinging_LCM_to_initial_call
org.restcomm.connect.testsuite.http.LiveCallModificationTest.holdCall
org.restcomm.connect.testsuite.http.LiveCallModificationTest.testTerminateDialForkCallWhileRinging_LCM_to_dial_branches
org.restcomm.connect.testsuite.http.LiveCallModificationTest.testTerminateDialForkCallWhileRinging_LCM_to_initial_call
org.restcomm.connect.testsuite.http.LiveCallModificationTest.testTerminateDialForkCallWhileRinging_LCM_to_move_initial_call_to_hangup_rcml
org.restcomm.connect.testsuite.http.UsageRecordsTest.getUsageRecordsDaily
org.restcomm.connect.testsuite.http.UsageRecordsTest.getUsageRecordsMonthly
org.restcomm.connect.testsuite.http.UsageRecordsTest.getUsageRecordsYearly
org.restcomm.connect.testsuite.http.UsageRecordsTest.getUsageRecordsAlltime
org.restcomm.connect.testsuite.provisioning.number.voxbone.VoxboneIncomingPhoneNumbersEndpointTest.testPurchaseAndDeletePhoneNumberSuccess
org.restcomm.connect.testsuite.provisioning.number.voxbone.VoxboneIncomingPhoneNumbersEndpointTest.testPurchasePhoneNumberNoPhoneNumberFound
org.restcomm.connect.testsuite.telephony.CallLifecycleTest.testDialCancelBeforeDialingClientAliceAfterTrying
org.restcomm.connect.testsuite.telephony.CallLifecycleTest.testDialCancelBeforeDialingClientAliceAfterRinging
org.restcomm.connect.testsuite.telephony.CallLifecycleTest.testDialClientAliceWithTimeLimit
org.restcomm.connect.testsuite.telephony.ClientsDialAnswerDelayTest.testClientDialOutPstnSimulateWebRTCClientNoAnswer
org.restcomm.connect.testsuite.telephony.ClientsDialTest.testDialClientAliceWithExtraParamsAtContactHeader
org.restcomm.connect.testsuite.telephony.ClientsDialTest.testClientsCallEachOther
org.restcomm.connect.testsuite.telephony.DialRecordingS3UploadAnswerDelayTest.testDialClientAlice_BobDisconnects
org.restcomm.connect.testsuite.telephony.DialRecordingS3UploadAnswerDelayTest.testDialClientAlice_AliceDisconnects
org.restcomm.connect.testsuite.telephony.ImsClientsDialAnswerDelayTest.testWebRTCClientIncomingBusy
org.restcomm.connect.testsuite.telephony.ImsClientsDialAnswerDelayTest.testWebRTCClientIncomingBHold
org.restcomm.connect.testsuite.telephony.ImsClientsDialAnswerDelayTest.testWebRTCClientOutgoingAHold
org.restcomm.connect.testsuite.telephony.ImsClientsDialTest.testWebRTCClientIncomingADisconnect
org.restcomm.connect.testsuite.telephony.ReferTest.org.restcomm.connect.testsuite.telephony.ReferTest
org.restcomm.connect.testsuite.telephony.TestDialVerbPartTwo.testDialConferenceNoDialActionNoSms
org.restcomm.connect.testsuite.telephony.TestDialVerbPartTwo.testDialClientAliceWithRecordAndStatusCallbackForAppForThreeCalls
org.restcomm.connect.testsuite.telephony.TestDialVerbPartTwo.testRecordWithActionAndStatusCallbackForAppWithBobSendsFinishKey
org.restcomm.connect.testsuite.telephony.TestMgcpOperations.testDialHelloPlay