### PR TITLE
Deploy/undeploy bundled RVD through configuration

### DIFF
--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/advanced.conf
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/advanced.conf
@@ -93,7 +93,7 @@ LBHOST='' #Obligatory to set if Load Balancer is used for PSTN (DID provider con
 #RVD workspace path. (If not set default will be used).
 #Default: leave empty.
 RVD_LOCATION=''
-RVD_URL='' # override if RVD is not under the same domain with restcomm. Use a base url like http://myrvd.restcomm.com . No path included.
+RVD_URL='' # override if RVD is not under the same domain with restcomm. Use a base url like http://myrvd.restcomm.com . No path included. Also, if provided, bundled RVD will get undeployed.
 RVD_VIDEO_SUPPORT='false'  # Toggle RVD Video RCML generation and UI
 RVD_MAX_MEDIA_FILE_SIZE=4194304 # Limit media file size when uploading. For video should probably be greater
 

--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
@@ -540,24 +540,49 @@ otherRestCommConf(){
     echo "End Rest RestComm configuration"
 }
 
-confRVD(){
-    echo "Configure RVD"
-	if [ -n "$RVD_LOCATION" ]; then
-  		echo "RVD_LOCATION $RVD_LOCATION"
-  		mkdir -p `echo $RVD_LOCATION`
-  		sed -i "s|<workspaceLocation>.*</workspaceLocation>|<workspaceLocation>${RVD_LOCATION}</workspaceLocation>|" $RVD_DEPLOY/WEB-INF/rvd.xml
-
-  		COPYFLAG=$RVD_LOCATION/.demos_initialized
-  		if [ -f "$COPYFLAG" ]; then
-   			#Do nothing, we already copied the demo file to the new workspace
-    		echo "RVD demo application are already copied"
-  		else
-    		echo "Will copy RVD demo applications to the new workspace $RVD_LOCATION"
-    		cp -ar $RVD_DEPLOY/workspace/* $RVD_LOCATION
-    		touch $COPYFLAG
-  		fi
-
+disableRVD() {
+	echo "disabling bundled RVD..."
+    if [ -f "$RVD_DEPLOY.deployed" ]; then
+		rm "$RVD_DEPLOY.deployed"
+    	echo "RVD un-deployed"
+	else
+		echo "RVD already not deployed"
 	fi
+}
+
+enableRVD() {
+    echo "enabling bundled RVD..."
+	if [ -f "$RVD_DEPLOY.deployed" ]; then
+		echo "RVD already deployed"
+	else
+		touch "$RVD_DEPLOY".dodeploy
+		echo "RVD enabled/deployed"
+	fi
+}
+
+confRVD(){
+    if [ -z "$RVD_URL" ]; then
+        enableRVD
+        echo "Configure bundled RVD"
+        if [ -n "$RVD_LOCATION" ]; then
+            echo "RVD_LOCATION $RVD_LOCATION"
+            mkdir -p `echo $RVD_LOCATION`
+            sed -i "s|<workspaceLocation>.*</workspaceLocation>|<workspaceLocation>${RVD_LOCATION}</workspaceLocation>|" $RVD_DEPLOY/WEB-INF/rvd.xml
+
+            COPYFLAG=$RVD_LOCATION/.demos_initialized
+            if [ -f "$COPYFLAG" ]; then
+                #Do nothing, we already copied the demo file to the new workspace
+                echo "RVD demo application are already copied"
+            else
+                echo "Will copy RVD demo applications to the new workspace $RVD_LOCATION"
+                cp -ar $RVD_DEPLOY/workspace/* $RVD_LOCATION
+                touch $COPYFLAG
+            fi
+
+        fi
+    else
+        disableRVD
+    fi
 }
 
 ## Adds/removes <rcmlserver>/<base-url> element based on $RVD_URL

--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
@@ -541,22 +541,21 @@ otherRestCommConf(){
 }
 
 disableRVD() {
-	echo "disabling bundled RVD..."
-    if [ -f "$RVD_DEPLOY.deployed" ]; then
-		rm "$RVD_DEPLOY.deployed"
-    	echo "RVD un-deployed"
+    if [[ -f "$RVD_DEPLOY.deployed" || -f "$RVD_DEPLOY.dodeploy" ]]; then
+		rm -f "$RVD_DEPLOY.deployed"
+		rm -f "$RVD_DEPLOY.dodeploy"
+    	echo "RVD undeployed (or not deployed at all)"
 	else
-		echo "RVD already not deployed"
+		echo "RVD not deployed"
 	fi
 }
 
 enableRVD() {
-    echo "enabling bundled RVD..."
 	if [ -f "$RVD_DEPLOY.deployed" ]; then
 		echo "RVD already deployed"
 	else
 		touch "$RVD_DEPLOY".dodeploy
-		echo "RVD enabled/deployed"
+		echo "RVD deployed"
 	fi
 }
 

--- a/restcomm/restcomm.commons/src/main/java/org/restcomm/connect/commons/amazonS3/S3AccessTool.java
+++ b/restcomm/restcomm.commons/src/main/java/org/restcomm/connect/commons/amazonS3/S3AccessTool.java
@@ -125,7 +125,7 @@ public class S3AccessTool {
                     if (logger.isInfoEnabled()) {
                         logger.info("Will thread sleep for 1 minute simulating the long operation of FileUtils.waitFor");
                     }
-                    Thread.sleep(60000);
+                    Thread.sleep(6000);
                 } catch (Exception e) {
                     logger.error("Exception while sleepig simulating the long operation waiting for the file");
 


### PR DESCRIPTION
Added configuration in restcomm-config.sh that controls whether RVD is deployed or not based on the RVD_URL parameter in advanced.conf. By default (RVD_URL is empty) it will get deployed. 

Currently, this PR will make no difference to a a restcomm installation. In an RVD microservice setup when RVD_URL will point to a remote RVD, the bundled version will get undpeloyed.

Refers to #2350 