### PR TITLE
Change CDR status in uppercase to lowercase for 'completed'

### DIFF
--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/scripts/mariadb/sql/call-detail-records.xml
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/scripts/mariadb/sql/call-detail-records.xml
@@ -209,7 +209,7 @@
 
   <update id="updateInCompleteCallDetailRecordsToCompletedByInstanceId" parameterType="string">
     UPDATE restcomm_call_detail_records
-      SET status='COMPLETED'
+      SET status='completed'
       WHERE instanceid=#{instanceid} AND (UPPER(status) = ('IN_PROGRESS') OR 
         UPPER(status) = ('IN-PROGRESS') OR UPPER(status) = ('RINGING') OR UPPER(status) = ('QUEUED'));
   </update>

--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/sql/call-detail-records.xml
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/sql/call-detail-records.xml
@@ -207,7 +207,7 @@
   </update>
   <update id="updateInCompleteCallDetailRecordsToCompletedByInstanceId" parameterType="string">
     UPDATE "restcomm_call_detail_records"
-      SET "status"='COMPLETED'
+      SET "status"='completed'
       WHERE "instanceid"=#{instanceid} AND (UPPER("status") = ('IN_PROGRESS') OR 
         UPPER("status") = ('IN-PROGRESS') OR UPPER("status") = ('RINGING') OR UPPER("status") = ('QUEUED'));
   </update>


### PR DESCRIPTION
Change CDR status to lowercase **completed** when `updateInCompleteCallDetailRecordsToCompletedByInstanceId` applies. This is for partially solving issue #2162 and related Zendesk ticket #34316. New issues will be raised to solve other problems mentioned in the concerning issue.