### PR TITLE
Tweaked configuration scripts to work with RVD_UNDEPLOY env variable

### DIFF
--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/advanced.conf
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/advanced.conf
@@ -93,7 +93,8 @@ LBHOST='' #Obligatory to set if Load Balancer is used for PSTN (DID provider con
 #RVD workspace path. (If not set default will be used).
 #Default: leave empty.
 RVD_LOCATION=''
-RVD_URL='' # override if RVD is not under the same domain with restcomm. Use a base url like http://myrvd.restcomm.com . No path included. Also, if provided, bundled RVD will get undeployed.
+RVD_UNDEPLOY='false'
+RVD_URL='' # override if RVD is not under the same domain with restcomm. Use a base url like http://myrvd.restcomm.com . No path included. This affects restcomm.xml/<rcmlserver/>
 RVD_VIDEO_SUPPORT='false'  # Toggle RVD Video RCML generation and UI
 RVD_MAX_MEDIA_FILE_SIZE=4194304 # Limit media file size when uploading. For video should probably be greater
 

--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-rvd.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-rvd.sh
@@ -43,24 +43,27 @@ updateMaxMediaFileSize() {
 
 # MAIN
 
-if [ -z "$RESTCOMM_HOME" ]
-then
-    echo "RESTCOMM_HOME env variable not set. Aborting."
-    exit 1
-fi
-if [ ! -f "$RVD_XML_FILE" ]
-then
-    echo "rvd.xml not found. Aborting."
-    return
-fi
-
-echo "Configuring RVD"
-
-if [[ "$RVD_VIDEO_SUPPORT" = true || "$RVD_VIDEO_SUPPORT" = TRUE || "$RVD_VIDEO_SUPPORT" = True ]] ; then
-    updateVideoSupport true
+if [[ "$RVD_UNDEPLOY" = true || "$RVD_UNDEPLOY" = TRUE || "$RVD_UNDEPLOY" != True ]]; then
+    echo "Skipping RVD configuration since it's not deployed"
 else
-    updateVideoSupport false
-fi
-updateMaxMediaFileSize "$RVD_MAX_MEDIA_FILE_SIZE"
-echo "Updated rvd.xml"
+    if [ -z "$RESTCOMM_HOME" ]
+    then
+        echo "RESTCOMM_HOME env variable not set. Aborting."
+        exit 1
+    fi
+    if [ ! -f "$RVD_XML_FILE" ]
+    then
+        echo "rvd.xml not found. Aborting."
+        return
+    fi
 
+    echo "Configuring RVD"
+
+    if [[ "$RVD_VIDEO_SUPPORT" = true || "$RVD_VIDEO_SUPPORT" = TRUE || "$RVD_VIDEO_SUPPORT" = True ]] ; then
+        updateVideoSupport true
+    else
+        updateVideoSupport false
+    fi
+    updateMaxMediaFileSize "$RVD_MAX_MEDIA_FILE_SIZE"
+    echo "Updated rvd.xml"
+fi


### PR DESCRIPTION
Adds RVD_UNDEPLOY configuration option that controls deploying/undeploying of RVD. Also, it disables RVD configuration in case it is not deployed.

It will be used in microservice setups but also makes sense in setups where RVD is not part of the game.

This relates to issue #2505 
