### PR TITLE
New deliverable dependant download approach

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -20,10 +20,14 @@ Inside file
 ddd-versions.properties
 ```
 you will find the configuration of the deliverables, which are going to be downloaded. In case you want to use default and predefined versions
-as you cloned from the repository, do not change anything. For adavance usage and testing a different versions, it is your responsibility to 
+as you cloned from the repository, do not change anything. For advance usage and testing a different versions, it is your responsibility to 
 define proper versions.
+For those able to access the [TeleStax](http://www.telestax.com/), Inc. infrastructure and AWS S3, take advantage of using the 
+```
+ant -f ddd-s3-box.xml s3
+```
 
-To build the Rescomm Connect project itself please use:
+To build the Restcomm Connect project itself please use:
 ```
 ant -f build.xml
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,47 @@
+RestComm build
+========
+Since RestComm is lead by [TeleStax](http://www.telestax.com/), Inc. and developed collaboratively by a community of individual and enterprise contributors it does not prevent You to try 
+the community version and build Yourself.
+Before the build itself you are required to download the dependent deliverables. 
+Use following commands: 
+```
+ant -f ddd-s3-box.xml box 
+```
+to download the dependent deliverables for Restcomm Connect, which are
+* [Sip Servlets](https://github.com/RestComm/sip-servlets)
+* [Media Server](https://github.com/RestComm/mediaserver)
+* [Olympus](https://github.com/RestComm/olympus)
+* [Visual Designer](https://github.com/RestComm/visual-designer)
+
+All mentioned above, must be built and available prior to your build of RestComm Connect, so please make sure to get familiar with 
+those projects too.
+Inside file 
+```
+ddd-versions.properties
+```
+you will find the configuration of the deliverables, which are going to be downloaded. In case you want to use default and predefined versions
+as you cloned from the repository, do not change anything. For adavance usage and testing a different versions, it is your responsibility to 
+define proper versions.
+
+To build the Rescomm Connect project itself please use:
+```
+ant -f build.xml
+```
+Optionaly, if you want to provide your own settings.xml for your inner maven build use:
+
+```
+ant -f build.xml -Dmvn.arg='-s ${location of your settings.xml file}'
+```
+Other possible targets to use are:
+```
+deploy, release-test
+```
+
+Check the build.xml for more details and specifically properties section
+```
+  \<property name="release.build.goals" value="clean install -Dmaven.test.skip=true"/\>
+  \<property name="release.build.test.goals" value="clean install -Dmaven.test.failure.ignore=true"/\>
+  \<property name="release.ts.deploy.goals" value="clean deploy"/\>
+
+```
+

--- a/release/build.xml
+++ b/release/build.xml
@@ -1,85 +1,50 @@
 <?xml version="1.0"?>
 <project basedir="." default="release" name="restcomm.release">
-  <property environment="sys"/>
-  <property location="${ant.file.restcomm.release}/../target" name="release.dir"/>
-  <property location="${ant.file.restcomm.release}/../target-tomcat" name="release.tomcat.dir"/>
-  <property location="${ant.file.restcomm.release}/../target-as7" name="release.as7.dir"/>
-  <property location="${ant.file.restcomm.release}/.." name="base.dir"/>
-  <property location="${release.dir}/docs" name="docs.dir"/>
-  <property location="${release.dir}/docs/restcomm" name="restcomm.docs.dir"/>
-  <property location="${release.tomcat.dir}/docs/restcomm" name="restcomm.docs.tomcat.dir"/>
-  <property location="${release.as7.dir}/docs/restcomm" name="restcomm.docs.as7.dir"/>
-  <property name="olympus.build" value="18"/>
-  <property location="${workspace.restcomm.dir}/configuration" name="configuration.directory"/>
-
-  <!--mobicents binaries versions-->
-  <property name="sipservlets-build" value="782"/>
-  <property name="restcomm-sipservlets-as7.version" value="3.1.${sipservlets-build}"/>
-  <!--<property name="jain-sip-ri.version" value="7.0.3.190" />-->
-  <property name="restcomm-media.version" value="6.0"/>
-  <property name="restcomm-media.build" value="23"/>
-  <!--property name="mobicents-diameter.version" value="6.1.2.GA" /-->
-
-  <!-- mobicents SIP Servlets 7.x on JBoss AS7-->
-  <property name="restcomm-sipservlets.as7.distro.version" value="${restcomm-sipservlets-as7.version}-jboss-as-7.2.0.Final"/>
-  <property name="restcomm-sipservlets.as7.download.distro.file" value="restcomm-sip-servlets-${restcomm-sipservlets.as7.distro.version}.zip"/>
-  <property name="restcomm-sipservlets.as7.download.url" value="https://mobicents.ci.cloudbees.com/job/RestcommSipServlets-Release/${sipservlets-build}/artifact/${restcomm-sipservlets.as7.download.distro.file}"/>
-  <property name="restcomm-sipservlets.as7.distro.zip.path" value="${checkout.dir}/${restcomm-sipservlets.as7.download.distro.file}"/>
-
-  <property name="restcomm-media.download.distro.file" value="restcomm-media-server.zip"/>
-  <!--<property name="mobicents-media.download.url" value="https://github.com/Mobicents/mediaserver/releases/download/3.0.2.FINAL/mms-server-3.0.2.Final.zip" />-->
-  <!--property name="mobicents-media.download.url" value="https://mobicents.ci.cloudbees.com/view/MediaServer/job/Mobicents-MediaServer-2.x/lastSuccessfulBuild/artifact/bootstrap/target/mms-server.zip" /-->
-  <!--property name="mobicents-media.download.url" value="https://mobicents.ci.cloudbees.com/view/MediaServer/job/Mobicents-MediaServer-4.x/lastSuccessfulBuild/artifact/bootstrap/target/mms-server.zip"/-->
-  <property name="restcomm-media.download.url" value="https://mobicents.ci.cloudbees.com/view/MediaServer/job/Restcomm-MediaServer-6.x/${restcomm-media.build}/artifact/bootstrap/target/restcomm-media-server.zip"/>
-  <property name="restcomm-media.distro.zip.path" value="${checkout.dir}/${restcomm-media.download.distro.file}"/>
-
-  <!-- <property name="restcomm-olympus.download.url" value="https://mobicents.ci.cloudbees.com/job/Olympus/${olympus.build}/artifact/target/olympus.war"/> -->
-  <property name="restcomm-olympus.download.url" value="https://mobicents.ci.cloudbees.com/job/Olympus-2.X/lastSuccessfulBuild/artifact/target/olympus.war"/>
-  <property name="restcomm-olympus.path" value="${configuration.directory}/olympus.war"/>
-
-  <!-- Determine RVD retrieval URL
-
-       If 'rvd.version' command-line parameter is set, the binary is retrieved from sonatype maven repo.
-       Otherwise, the latest release binary from github is fetched.
-
-       Result assigned to: restcomm-rvd.download.url
-  -->
-  <!-- determine rvd github download url -->
-  <get src="https://api.github.com/repos/RestComm/visual-designer/releases/latest" dest="${configuration.directory}/rvd-latest-release.json"></get>
-  <replaceregexp file="${configuration.directory}/rvd-latest-release.json" match='.*"browser_download_url":"([^"]+)".*' replace="\1"/>
-  <loadfile property="restcomm-rvd.github-download.url" srcFile="${configuration.directory}/rvd-latest-release.json"/>
-  <property name="restcomm-rvd.path" value="${configuration.directory}/restcomm-rvd.war"/>
-  <delete file="${configuration.directory}/rvd-latest-release.json"/>
-
-  <condition property="restcomm-rvd.download.url" value="https://oss.sonatype.org/content/groups/public/org/restcomm/restcomm-connect-rvd/${rvd.version}/restcomm-connect-rvd-${rvd.version}.war" else="${restcomm-rvd.github-download.url}">
-    <isset property="rvd.version"></isset>
-  </condition>
-  <echo>Will retrieve RVD from ${restcomm-rvd.download.url}</echo>
-  <!-- check actual availability of RVD at the determined URL-->
-  <fail message="RVD binary not available at ${restcomm-rvd.download.url}">
-    <condition>
-      <not>
-        <http url="${restcomm-rvd.download.url}"></http>
-      </not>
-    </condition>
-  </fail>
-
-  <property name="release.build.goals" value="clean install -Dmaven.test.skip=true"/>
-  <property name="release.build.test.goals" value="clean install -Dmaven.test.failure.ignore=true"/>
-  <property name="release.ts.deploy.goals" value="clean deploy"/>
-
   <condition else="mvn" property="mvn.executable" value="${sys.M2_HOME}\bin\mvn.bat">
     <os family="windows"/>
   </condition>
-
   <taskdef onerror="fail" resource="net/sf/antcontrib/antlib.xml">
     <classpath>
       <pathelement location="${ant.file.restcomm.release}/../ant-contrib-1.0b3.jar"/>
     </classpath>
   </taskdef>
+  <property environment="sys"/>
+  <property name="mvn.arg" value=""/>
+  <property name="release.dir" location="${ant.file.restcomm.release}/../target"/>
+  <property name="release.tomcat.dir" location="${ant.file.restcomm.release}/../target-tomcat"/>
+  <property name="release.as7.dir" location="${ant.file.restcomm.release}/../target-as7"/>
+  <property name="base.dir" location="${ant.file.restcomm.release}/.."/>
+  <property name="docs.dir" location="${release.dir}/docs"/>
+  <property name="restcomm.docs.dir" location="${release.dir}/docs/restcomm"/>
+  <property name="restcomm.docs.tomcat.dir" location="${release.tomcat.dir}/docs/restcomm"/>
+  <property name="restcomm.docs.as7.dir" location="${release.as7.dir}/docs/restcomm"/>
+  <property name="workspace.restcomm.dir" location="${base.dir}/../restcomm"/>
+  <property name="configuration.directory" location="${workspace.restcomm.dir}/configuration"/>
+  <property name="download.dir" location="${base.dir}/ddd"/>
 
-  <target depends="clean,get-deps,extract-deps,build-restcomm, copy-restcomm, copy-docs, make-final-zip" name="release"/>
-  <target depends="get-deps,extract-deps,build-restcomm, copy-restcomm, copy-docs, make-final-zip" name="release-no-clean"/>
+  <property name="restcomm.release.version" value="8.x.x-SNAPSHOT"/>
+
+  <!-- mobicents SIP Servlets 7.x on JBoss AS7-->
+  <property name="restcomm-sipservlets.as7.download.distro.file" value="restcomm-sip-servlets.zip"/>
+  <property name="restcomm-sipservlets.as7.distro.zip.path" value="${download.dir}/${restcomm-sipservlets.as7.download.distro.file}"/>
+
+  <property name="restcomm-media.download.distro.file" value="media-server-standalone.zip"/>
+  <property name="restcomm-media.distro.zip.path" value="${download.dir}/${restcomm-media.download.distro.file}"/>
+
+  <property name="restcomm-olympus.download.distro.file" value="olympus.war"/>
+  <property name="restcomm-olympus.distro.file.path" value="${download.dir}/${restcomm-olympus.download.distro.file}"/>
+  <property name="restcomm-olympus.path" value="${configuration.directory}/olympus.war"/>
+
+  <property name="restcomm-rvd.download.distro.file" value="restcomm-rvd.war"/>
+  <property name="restcomm-rvd.distro.file.path" value="${download.dir}/${restcomm-rvd.download.distro.file}"/>
+  <property name="restcomm-rvd.path" value="${configuration.directory}/restcomm-rvd.war"/>
+
+  <property name="release.build.goals" value="clean install -Dmaven.test.skip=true"/>
+  <property name="release.build.test.goals" value="clean install -Dmaven.test.failure.ignore=true"/>
+  <property name="release.ts.deploy.goals" value="clean deploy"/>
+
+  <target depends="clean,deps,build-restcomm, copy-restcomm, copy-docs, make-final-zip" name="release"/>
+  <target depends="deps,build-restcomm, copy-restcomm, copy-docs, make-final-zip" name="release-no-clean"/>
 
   <target name="deploy">
     <ant antfile="${ant.file.restcomm.release}" target="release">
@@ -105,87 +70,50 @@
     </ant>
   </target>
 
-  <!--GET mobicents-Sip=Servlets & mobicents-Media-Server & mobicents Diameter - downloads-->
-
-  <target depends="get-restcomm-sipservlets-as7,get-restcomm-media,get-olympus,get-rvd" name="get-deps"/>
-  <target depends="extract-restcomm-sipservlets-as7,extract-restcomm-media" name="extract-deps"/>
+  <target name="deps" depends="deps-restcomm-sipservlets-as7,deps-restcomm-media, deps-olympus, deps-rvd"/>
 
   <!--SipServlets JBoss AS7 -->
-  <available file="${restcomm-sipservlets.as7.distro.zip.path}" property="got.restcomm-sipservlets-as7"/>
-  <target name="get-restcomm-sipservlets-as7" unless="got.restcomm-sipservlets-as7">
-    <echo>Downloading Restcomm SipServlets JBoss AS7 version: ${restcomm-sipservlets-as7.version}</echo>
-    <exec executable="wget" failonerror="true">
-      <arg value="${restcomm-sipservlets.as7.download.url}"/>
-    </exec>
-    <move file="${base.dir}/${restcomm-sipservlets.as7.download.distro.file}" todir="${checkout.dir}"/>
-  </target>
-
-  <target depends="get-restcomm-sipservlets-as7" name="extract-restcomm-sipservlets-as7">
-    <delete dir="${checkout.restcomm-sipservlets-as7.dir}" failonerror="false"/>
+  <target name="deps-restcomm-sipservlets-as7">
     <unzip dest="${release.as7.dir}" src="${restcomm-sipservlets.as7.distro.zip.path}">
-      <mapper from="restcomm-sip-servlets-${restcomm-sipservlets-as7.version}-jboss-as-7.2.0.Final/*" to="*" type="glob"/>
+      <cutdirsmapper dirs="1"/>
     </unzip>
   </target>
 
   <!--Media-->
-  <available file="${restcomm-media.distro.zip.path}" property="got.restcomm-media"/>
-  <target name="get-restcomm-media" unless="got.restcomm-media">
-    <echo>Downloading Restcomm Media version: ${restcomm-media.version}.${restcomm-media.build}</echo>
-    <exec executable="wget" failonerror="true">
-      <arg value="${restcomm-media.download.url}"/>
-    </exec>
-    <move file="${base.dir}/restcomm-media-server.zip" todir="${checkout.dir}"/>
-    <move file="${checkout.dir}/restcomm-media-server.zip" tofile="${checkout.dir}/${restcomm-media.download.distro.file}"/>
-  </target>
-
-  <!--Olympus-->
-  <available file="${restcomm-olympus.path}" property="got.olympus"/>
-  <target name="get-olympus" unless="got.olympus">
-    <echo>Downloading Restcomm Olympus version: ${olympus.version}</echo>
-    <exec executable="wget" failonerror="true">
-      <arg value="${restcomm-olympus.download.url}"/>
-    </exec>
-    <move file="${base.dir}/olympus.war" todir="${configuration.directory}"/>
-  </target>
-
-  <!-- RVD -->
-  <available file="${restcomm-rvd.path}" property="got.rvd"/>
-  <target name="get-rvd" unless="got.rvd">
-    <echo>Downloading latest version of Visual Designer</echo>
-    <exec executable="wget" failonerror="true">
-      <arg value="${restcomm-rvd.download.url}"/>
-    </exec>
-    <move file="${base.dir}/restcomm-rvd.war" todir="${configuration.directory}"/>
-  </target>
-
-  <target depends="get-restcomm-media" name="extract-restcomm-media">
-    <delete dir="${checkout.restcomm-media.dir}" failonerror="false"/>
+  <target name="deps-restcomm-media">
     <delete dir="${release.as7.dir}/mobicents-media-server" failonerror="false"/>
-    <!--unzip src="${mobicents-media.distro.zip.path}" dest="${release.dir}/mobicents-media"/-->
-    <unzip dest="${release.as7.dir}/mediaserver" src="${restcomm-media.distro.zip.path}"/>
-    <move todir="${release.as7.dir}/mediaserver">
-      <fileset dir="${release.as7.dir}/mediaserver/restcomm-media-server"/>
-    </move>
-    <!-- copy failonerror="true" file="${configuration.directory}/mms-server-beans.xml" tofile="${release.as7.dir}/mediaserver/deploy/server-beans.xml"/ -->
+    <unzip dest="${release.as7.dir}/mediaserver" src="${restcomm-media.distro.zip.path}">
+      <cutdirsmapper dirs="1"/>
+    </unzip>
     <chmod dir="${release.as7.dir}/mediaserver" includes="**/*.sh" perm="ugo+rx"/>
     <chmod dir="${release.as7.dir}/mediaserver/bin" includes="**/*.sh" perm="ugo+rx"/>
     <chmod dir="${release.as7.dir}/mediaserver/.autoconfig" includes="**/*.sh" perm="ugo+rx"/>
     <chmod dir="${release.as7.dir}/mediaserver/.autoconfig/autoconfig.d" includes="**/*.sh" perm="ugo+rx"/>
   </target>
 
+  <!--Olympus-->
+  <available file="${restcomm-olympus.path}" property="got.olympus"/>
+  <target name="deps-olympus" unless="got.olympus">
+    <copy failonerror="true" file="${restcomm-olympus.distro.file.path}" todir="${configuration.directory}"/>
+  </target>
+
+  <!-- RVD -->
+  <available file="${restcomm-rvd.path}" property="got.rvd"/>
+  <target name="deps-rvd" unless="got.rvd">
+    <copy failonerror="true" file="${restcomm-rvd.distro.file.path}" todir="${configuration.directory}"/>
+  </target>
+
+
   <target name="build-restcomm">
     <echo>Building Restcomm</echo>
     <echo>Restcomm workspace dir: "${workspace.restcomm.dir}"</echo>
     <exec dir="${workspace.restcomm.dir}" executable="${mvn.executable}" failonerror="true">
       <arg line="${release.build.goals}"/>
+      <arg line="${mvn.arg}"/>
     </exec>
-    <!--
-    <exec dir="${workspace.restcomm.dir}/restcomm.docs" executable="${mvn.executable}" failonerror="true">
-      <arg line="${release.build.goals} -Pmobicents"/>
-    </exec>
-  -->
     <exec dir="${workspace.restcomm.dir}/restcomm.provisioning.number.api" executable="${mvn.executable}" failonerror="true">
       <arg line="javadoc:javadoc"/>
+      <arg line="${mvn.arg}"/>
     </exec>
   </target>
 

--- a/release/ddd-s3-box.xml
+++ b/release/ddd-s3-box.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<project basedir="." default="download" name="download">
+  <taskdef onerror="fail" resource="net/sf/antcontrib/antlib.xml">
+    <classpath>
+      <pathelement location="${ant.file.download}/../ant-contrib-1.0b3.jar"/>
+    </classpath>
+  </taskdef>
+
+  <property name="ddd.folder" value="ddd"/>
+  <property name="versions.file" value="ddd-versions.properties"/>
+  <property name="s3.cmd.prefix" value="s3://cxs-artifacts"/>
+  <mkdir dir="${ddd.folder}"/>
+
+  <target name="download">
+      <echo>Please specify the storage with selecting specific targets [box|s3]</echo>
+  </target>
+
+
+  <target name="box">
+	 
+	<property file="${versions.file}" prefix="x"/>
+	<propertyselector property="propertyList"
+	  delimiter=","
+ 	  match="download\.([^\.]*)\.filename"
+	  select="\1"
+	  casesensitive="false"/>
+	 
+	<for list="${propertyList}" param="sequence">
+	  <sequential>
+	    <echo>Downloading ${x.download.@{sequence}.filename}</echo>
+	    <!--echo>${x.download.@{sequence}.s3url}</echo>
+	    <echo>${x.download.@{sequence}.boxurl}</echo-->
+            <available file="${ddd.folder}/${x.download.@{sequence}.filename}" property="got.file"/>
+	    <antcall target="get-file-box">
+              <param name="filename" value="${x.download.@{sequence}.filename}"/>
+              <param name="s3url" value="${x.download.@{sequence}.s3url}"/>
+              <param name="boxurl" value="${x.download.@{sequence}.boxurl}"/>
+           </antcall>
+	  </sequential>
+	</for>
+  </target>
+
+  <target name="get-file-box" unless="got.file">
+    <exec executable="wget" failonerror="true">
+      <arg value="-O"/>
+      <arg value="${ddd.folder}/${filename}"/>
+      <arg value="${boxurl}"/>
+    </exec>
+  </target>
+
+  <target name="s3">
+	<property file="ddd-versions.properties" prefix="x"/>
+	<propertyselector property="propertyList"
+	  delimiter=","
+ 	  match="download\.([^\.]*)\.filename"
+	  select="\1"
+	  casesensitive="false"/>
+	 
+	<for list="${propertyList}" param="sequence">
+	  <sequential>
+	    <echo>Downloading ${x.download.@{sequence}.filename}</echo>
+            <available file="${ddd.folder}/${x.download.@{sequence}.filename}" property="got.file"/>
+	    <antcall target="get-file-s3">
+              <param name="filename" value="${x.download.@{sequence}.filename}"/>
+              <param name="s3url" value="${x.download.@{sequence}.s3url}"/>
+              <param name="boxurl" value="${x.download.@{sequence}.boxurl}"/>
+           </antcall>
+	  </sequential>
+	</for>
+  </target>
+
+  <target name="get-file-s3" unless="got.file">
+    <exec executable="s3cmd" failonerror="true">
+      <arg value="get"/>
+      <arg value="--recursive"/>
+      <arg value="${s3.cmd.prefix}/${s3url}"/>
+      <arg value="${ddd.folder}/${filename}"/>
+    </exec>
+  </target>
+
+  <target name="get-file-s3-win">
+    <exec executable="${PYTHON_DIR}\python.exe" failonerror="true">
+      <arg value="${PYTHON_DIR}\Scripts\s3cmd" />
+      <arg value="get"/>
+      <arg value="--recursive"/>
+      <arg value="${s3.cmd.prefix}/${s3url}"/>
+      <arg value="${ddd.folder}/${filename}"/>
+    </exec>
+  </target>
+</project>

--- a/release/ddd-s3-box.xml
+++ b/release/ddd-s3-box.xml
@@ -17,7 +17,6 @@
 
 
   <target name="box">
-	 
 	<property file="${versions.file}" prefix="x"/>
 	<propertyselector property="propertyList"
 	  delimiter=","
@@ -36,6 +35,7 @@
               <param name="s3url" value="${x.download.@{sequence}.s3url}"/>
               <param name="boxurl" value="${x.download.@{sequence}.boxurl}"/>
            </antcall>
+	   <var name="got.file" unset="true"/>
 	  </sequential>
 	</for>
   </target>
@@ -65,6 +65,7 @@
               <param name="s3url" value="${x.download.@{sequence}.s3url}"/>
               <param name="boxurl" value="${x.download.@{sequence}.boxurl}"/>
            </antcall>
+	   <var name="got.file" unset="true"/>
 	  </sequential>
 	</for>
   </target>

--- a/release/ddd-versions.properties
+++ b/release/ddd-versions.properties
@@ -2,24 +2,29 @@
 # 		DDD versions property file 				  #
 ##########################################################################
 #									#
-# Usage								       #
-# download.[#].filename=[name of file]                                #
-# download.[#].s3url=[S3 partial link pointing to version file]      #
-# download.[#].boxurl=[Box static download link]                    #
-# 							           #
-###################################################################                 
+# Usage                                                                #
+# download.[#].version=[version of release]			      #
+# download.[#].filename=[filename alias to download]                 #
+# download.[#].s3url=[S3 partial link pointing to version file]     #
+# download.[#].boxurl=[Box static download link]                   #
+# 							          #
+##################################################################                 
+download.1.version=3.2.0-80
 download.1.filename=restcomm-sip-servlets.zip
 download.1.s3url=upstream/ci-mirror/jobs/UPS_RestcommSipServlets-Release/80/restcomm-sip-servlets-3.2.0-80-jboss-as-7.2.0.Final.zip
 download.1.boxurl=https://app.box.com/shared/static/yay6y2kwb5dmzjbzl471bk1z4bg5ysbt.zip
 
+download.2.version=7.0.0-20
 download.2.filename=media-server-standalone.zip
 download.2.s3url=upstream/ci-mirror/jobs/media-server-standalone-7/20/restcomm-media-server-7.0.0-20.zip
 download.2.boxurl=https://app.box.com/shared/static/aojh92ln5z6ydfgvssleckfypg3peu7a.zip
 
+download.3.version=1.1.0-99
 download.3.filename=olympus.war
 download.3.s3url=upstream/ci-mirror/jobs/UPS_Olympus/99/olympus.war
 download.3.boxurl=https://app.box.com/shared/static/a100qy39txrtc9e5wr0m3ood02tliuie.war
 
+download.4.version=1.1.0-66
 download.4.filename=restcomm-rvd.war
 download.4.s3url=upstream/ci-mirror/jobs/UPS_VisualDesigner/66/restcomm-rvd.war
 download.4.boxurl=https://app.box.com/shared/static/i4afm017phcxgu4j4k0m74gfy97ux7np.war

--- a/release/ddd-versions.properties
+++ b/release/ddd-versions.properties
@@ -1,0 +1,25 @@
+############################################################################
+# 		DDD versions property file 				  #
+##########################################################################
+#									#
+# Usage								       #
+# download.[#].filename=[name of file]                                #
+# download.[#].s3url=[S3 partial link pointing to version file]      #
+# download.[#].boxurl=[Box static download link]                    #
+# 							           #
+###################################################################                 
+download.1.filename=restcomm-sip-servlets.zip
+download.1.s3url=upstream/ci-mirror/jobs/UPS_RestcommSipServlets-Release/80/restcomm-sip-servlets-3.2.0-80-jboss-as-7.2.0.Final.zip
+download.1.boxurl=https://app.box.com/shared/static/yay6y2kwb5dmzjbzl471bk1z4bg5ysbt.zip
+
+download.2.filename=media-server-standalone.zip
+download.2.s3url=upstream/ci-mirror/jobs/media-server-standalone-7/20/restcomm-media-server-7.0.0-20.zip
+download.2.boxurl=https://app.box.com/shared/static/aojh92ln5z6ydfgvssleckfypg3peu7a.zip
+
+download.3.filename=olympus.war
+download.3.s3url=upstream/ci-mirror/jobs/UPS_Olympus/99/olympus.war
+download.3.boxurl=https://app.box.com/shared/static/a100qy39txrtc9e5wr0m3ood02tliuie.war
+
+download.4.filename=restcomm-rvd.war
+download.4.s3url=upstream/ci-mirror/jobs/UPS_VisualDesigner/66/restcomm-rvd.war
+download.4.boxurl=https://app.box.com/shared/static/i4afm017phcxgu4j4k0m74gfy97ux7np.war


### PR DESCRIPTION
This is the new approach - which I would like to have for all the Restcomm projects in the foreseeable future. This might not be the ultimate solution, as we would like to have ultimately ALL Mavenized and then getting rid of Ant & Bash would be required and all the deliverables dependencies could be Maven repo based, never less  for now this process cleans the deliverables dependency, decouples projects build from downloads. Simplifies the mess around download links & versions.
Please @deruelle review the approach from over all perspective and @maria-farooq and @gvagenas review the changes to RC itself 
! NOTE  ! - @gvagenas  the versions defined in the versions property file (ddd-versions.properties) are not most probably what we want to use for RC stable build for now, so please review and obtain the correct versions checking with the Media, Olympus, RVD, SipServlets teams before merging to RC master!
Thanks for feedback !
cheers
Pavel