### PR TITLE
fixed hault condition https://telestax.atlassian.net/browse/RESTCOMM-…

### DIFF
--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGateway.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGateway.java
@@ -426,7 +426,7 @@ public class MockMediaGateway extends RestcommUntypedActor {
 
     }
 
-    private void createConnection (final Object message, final ActorRef sender) {
+    protected void createConnection (final Object message, final ActorRef sender) {
         final ActorRef self = self();
         final jain.protocol.ip.mgcp.message.CreateConnection crcx = (jain.protocol.ip.mgcp.message.CreateConnection) message;
         System.out.println(crcx.toString());

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGateway.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGateway.java
@@ -109,7 +109,7 @@ public class MockMediaGateway extends RestcommUntypedActor {
     private RevolvingCounter requestIdPool;
     private RevolvingCounter sessionIdPool;
     private RevolvingCounter transactionIdPool;
-    private RevolvingCounter connectionIdPool;
+    protected RevolvingCounter connectionIdPool;
     private RevolvingCounter endpointIdPool;
 
     private Map<String, String> connEndpointMap;

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
@@ -1,0 +1,44 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2014, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+package org.restcomm.connect.mgcp;
+
+import akka.actor.ActorRef;
+import akka.event.Logging;
+import akka.event.LoggingAdapter;
+
+public final class MockMediaGatewayConferenceLinkCreationError extends MockMediaGateway {
+    private final LoggingAdapter logger = Logging.getLogger(getContext().system(), this);
+
+    @Override
+    protected void createConnection (final Object message, final ActorRef sender) {
+        final jain.protocol.ip.mgcp.message.CreateConnection crcx = (jain.protocol.ip.mgcp.message.CreateConnection) message;
+        if(logger.isDebugEnabled())
+            logger.debug(crcx.toString());
+        // check if its a conference and call link request
+        if(crcx.getSecondEndpointIdentifier() != null && crcx.getSecondEndpointIdentifier().getLocalEndpointName() != null){
+            // if yes then fail this connection request
+            if(logger.isDebugEnabled())
+                logger.debug("got conference and call link request, will fail it!");
+        }else {
+            // if not then let daddy proceed with existing mocked mechanism.
+            super.createConnection(message, sender);
+        }
+    }
+}

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
@@ -22,6 +22,8 @@ package org.restcomm.connect.mgcp;
 import akka.actor.ActorRef;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
+import jain.protocol.ip.mgcp.message.CreateConnectionResponse;
+import jain.protocol.ip.mgcp.message.parms.ReturnCode;
 
 public final class MockMediaGatewayConferenceLinkCreationError extends MockMediaGateway {
     private final LoggingAdapter logger = Logging.getLogger(getContext().system(), this);
@@ -35,7 +37,8 @@ public final class MockMediaGatewayConferenceLinkCreationError extends MockMedia
         if(crcx.getSecondEndpointIdentifier() != null && crcx.getSecondEndpointIdentifier().getLocalEndpointName() != null){
             // if yes then fail this connection request
             if(logger.isDebugEnabled())
-                logger.debug("got conference and call link request, will fail it!");
+                logger.debug("got conference and call link request, will fail it! with error code Endpoint_Unknown");
+            sender.tell(new CreateConnectionResponse(self(), ReturnCode.Endpoint_Unknown, null), self());
         }else {
             // if not then let daddy proceed with existing mocked mechanism.
             super.createConnection(message, sender);

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
@@ -32,13 +32,13 @@ public final class MockMediaGatewayConferenceLinkCreationError extends MockMedia
     @Override
     protected void createConnection (final Object message, final ActorRef sender) {
         final jain.protocol.ip.mgcp.message.CreateConnection crcx = (jain.protocol.ip.mgcp.message.CreateConnection) message;
-        if(logger.isDebugEnabled())
-            logger.debug(crcx.toString());
+        if(logger.isInfoEnabled())
+            logger.info("createConnection: " +crcx.toString());
         // check if its a conference and call link request
-        if(crcx.getSecondEndpointIdentifier() != null && crcx.getSecondEndpointIdentifier().getLocalEndpointName() != null){
+        if(crcx.getSecondEndpointIdentifier() != null && crcx.getSecondEndpointIdentifier().getLocalEndpointName() != null && crcx.getSecondEndpointIdentifier().getLocalEndpointName().contains("cnf")){
             // if yes then fail this connection request
-            if(logger.isDebugEnabled())
-                logger.debug("got conference and call link request, will fail it! with error code Endpoint_Unknown");
+            if(logger.isInfoEnabled())
+                logger.info("got conference and call link request, will fail it! with error code Endpoint_Unknown");
             StringBuilder buffer = new StringBuilder();
             buffer.append(connectionIdPool.get());
             ConnectionIdentifier connId = new ConnectionIdentifier(buffer.toString());

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGatewayConferenceLinkCreationError.java
@@ -23,6 +23,7 @@ import akka.actor.ActorRef;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
 import jain.protocol.ip.mgcp.message.CreateConnectionResponse;
+import jain.protocol.ip.mgcp.message.parms.ConnectionIdentifier;
 import jain.protocol.ip.mgcp.message.parms.ReturnCode;
 
 public final class MockMediaGatewayConferenceLinkCreationError extends MockMediaGateway {
@@ -38,7 +39,10 @@ public final class MockMediaGatewayConferenceLinkCreationError extends MockMedia
             // if yes then fail this connection request
             if(logger.isDebugEnabled())
                 logger.debug("got conference and call link request, will fail it! with error code Endpoint_Unknown");
-            sender.tell(new CreateConnectionResponse(self(), ReturnCode.Endpoint_Unknown, null), self());
+            StringBuilder buffer = new StringBuilder();
+            buffer.append(connectionIdPool.get());
+            ConnectionIdentifier connId = new ConnectionIdentifier(buffer.toString());
+            sender.tell(new CreateConnectionResponse(self(), ReturnCode.Endpoint_Unknown, connId), self());
         }else {
             // if not then let daddy proceed with existing mocked mechanism.
             super.createConnection(message, sender);

--- a/restcomm/restcomm.monitoring.service/src/main/java/org/restcomm/connect/monitoringservice/MonitoringService.java
+++ b/restcomm/restcomm.monitoring.service/src/main/java/org/restcomm/connect/monitoringservice/MonitoringService.java
@@ -207,6 +207,7 @@ public class MonitoringService extends RestcommUntypedActor {
         } else if (MgcpEndpointDeleted.class.equals(klass)) {
             MgcpEndpointDeleted mgcpEndpointDeleted = (MgcpEndpointDeleted)message;
             mgcpEndpointMap.values().removeAll(Collections.singleton(mgcpEndpointDeleted.getEndpoint()));
+            logger.info("MonitoringService: Deleted endpoint: "+mgcpEndpointDeleted.getEndpoint());
             String endpoint = mgcpEndpointDeleted.getEndpoint();
             if (endpoint.contains("ivr")) {
                 mgcpEndpointsIvr.decrementAndGet();

--- a/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
@@ -1426,7 +1426,6 @@ public final class Call extends RestcommUntypedActor {
                             }
                             addCustomHeaders(resp);
                             resp.send();
-                        
                         }
                     }
                 } catch (Exception e) {

--- a/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
@@ -2595,7 +2595,8 @@ public final class Call extends RestcommUntypedActor {
                     // call should move to failed state so proper sip response is generated &
                     // call resources get cleaned up
                     logger.error("Call failed to join conference, media operation to connect call with conference failed.");
-                    // Let conference know the call exited the room so it does keep waiting for it to complete the join
+                    // Let conference know the call exited the room so 
+                    // it does not keep waiting for it to complete the join
                     this.conferencing = false;
                     this.conference.tell(new Left(self()), self);
                     this.conference = null;

--- a/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
@@ -2595,6 +2595,10 @@ public final class Call extends RestcommUntypedActor {
                     // call should move to failed state so proper sip response is generated &
                     // call resources get cleaned up
                     logger.error("Call failed to join conference, media operation to connect call with conference failed.");
+                    // Let conference know the call exited the room so it does keep waiting for it to complete the join
+                    this.conferencing = false;
+                    this.conference.tell(new Left(self()), self);
+                    this.conference = null;
                     fsm.transition(new Hangup("failed to join conference"), failed);
                 }
                 break;

--- a/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
@@ -2595,7 +2595,7 @@ public final class Call extends RestcommUntypedActor {
                     // call should move to failed state so proper sip response is generated &
                     // call resources get cleaned up
                     logger.error("Call failed to join conference, media operation to connect call with conference failed.");
-                    // Let conference know the call exited the room so 
+                    // Let conference know the call exited the room so
                     // it does not keep waiting for it to complete the join
                     this.conferencing = false;
                     this.conference.tell(new Left(self()), self);

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
@@ -160,43 +160,27 @@ public class DialConferenceConnectionFailureTest {
         assertTrue(!(georgeCall.getLastReceivedResponse().getStatusCode() >= 400));
 
         Thread.sleep(2000);
+        bobCall.listenForDisconnect();
+        georgeCall.listenForDisconnect();
+
+        assertTrue(bobCall.waitForDisconnect(80 * 1000));
+        assertTrue(georgeCall.waitForDisconnect(80 * 1000));
 
         int liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
         int liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
         logger.info("&&&&& LiveCalls: "+liveCalls);
         logger.info("&&&&& LiveCallsArraySize: "+liveCallsArraySize);
-        assertEquals(2, liveCalls);
-        assertEquals(2, liveCallsArraySize);
+        assertEquals(0, liveCalls);
+        assertEquals(0, liveCallsArraySize);
         assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
         int numOfParticipants = RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2);
         logger.info("Number of participants: "+numOfParticipants);
-        assertEquals(2, numOfParticipants);
+        assertEquals(0, numOfParticipants);
 
         JsonObject metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
         Map<String, Integer> mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
         int mgcpEndpoints = mgcpResources.get("MgcpEndpoints");
         int mgcpConnections = mgcpResources.get("MgcpConnections");
-
-        assertTrue(mgcpEndpoints>0);
-        assertTrue(mgcpConnections>0);
-
-        Thread.sleep(3000);
-
-        georgeCall.disconnect();
-        bobCall.disconnect();
-
-        Thread.sleep(5000);
-        liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
-        liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
-        assertEquals(0, liveCalls);
-        assertEquals(0, liveCallsArraySize);
-        assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
-        assertEquals(0, RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2));
-
-        metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
-        mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
-        mgcpEndpoints = mgcpResources.get("MgcpEndpoints");
-        mgcpConnections = mgcpResources.get("MgcpConnections");
 
         assertEquals(0, mgcpEndpoints);
         assertEquals(0, mgcpConnections);

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
@@ -144,26 +144,23 @@ public class DialConferenceConnectionFailureTest {
 
         bobCall.listenForDisconnect();
         assertTrue(bobCall.waitForDisconnect(80 * 1000));
-        Thread.sleep(2000);
+
+        Thread.sleep(3000);
 
         int liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
         int liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
-        logger.info("&&&&& LiveCalls: "+liveCalls);
-        logger.info("&&&&& LiveCallsArraySize: "+liveCallsArraySize);
         assertEquals(0, liveCalls);
         assertEquals(0, liveCallsArraySize);
         assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
         int numOfParticipants = RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2);
-        logger.info("Number of participants: "+numOfParticipants);
         assertEquals(0, numOfParticipants);
 
+        logger.info("going to check mgcpResources");
         JsonObject metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
         Map<String, Integer> mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
-        int mgcpEndpoints = mgcpResources.get("MgcpEndpoints");
-        int mgcpConnections = mgcpResources.get("MgcpConnections");
-
-        assertEquals(0, mgcpEndpoints);
-        assertEquals(0, mgcpConnections);
+        
+        assertEquals(0, (int)mgcpResources.get("MgcpEndpoints"));
+        assertEquals(0, (int)mgcpResources.get("MgcpConnections"));
     }
 
     @Deployment(name = "DialConferenceTest", managed = true, testable = false)

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
@@ -142,29 +142,9 @@ public class DialConferenceConnectionFailureTest {
         bobCall.sendInviteOkAck();
         assertTrue(!(bobCall.getLastReceivedResponse().getStatusCode() >= 400));
 
-        final SipCall georgeCall = georgePhone.createSipCall();
-        georgeCall.initiateOutgoingCall(georgeContact, dialRestcomm, null, body, "application", "sdp", null, null);
-        assertLastOperationSuccess(georgeCall);
-        assertTrue(georgeCall.waitOutgoingCallResponse(5 * 1000));
-        int responseGeorge = georgeCall.getLastReceivedResponse().getStatusCode();
-        assertTrue(responseGeorge == Response.TRYING || responseGeorge == Response.RINGING);
-
-        if (responseGeorge == Response.TRYING) {
-            assertTrue(georgeCall.waitOutgoingCallResponse(5 * 1000));
-            assertEquals(Response.RINGING, georgeCall.getLastReceivedResponse().getStatusCode());
-        }
-
-        assertTrue(georgeCall.waitOutgoingCallResponse(5 * 1000));
-        assertEquals(Response.OK, georgeCall.getLastReceivedResponse().getStatusCode());
-        georgeCall.sendInviteOkAck();
-        assertTrue(!(georgeCall.getLastReceivedResponse().getStatusCode() >= 400));
-
-        Thread.sleep(2000);
         bobCall.listenForDisconnect();
-        georgeCall.listenForDisconnect();
-
         assertTrue(bobCall.waitForDisconnect(80 * 1000));
-        assertTrue(georgeCall.waitForDisconnect(80 * 1000));
+        Thread.sleep(2000);
 
         int liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
         int liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
@@ -41,6 +41,7 @@ import com.google.gson.JsonObject;
 
 /**
  * @author mariafarooq
+ * https://telestax.atlassian.net/browse/RESTCOMM-1343
  */
 @RunWith(Arquillian.class)
 @Category(value={SequentialClassTests.class})
@@ -117,7 +118,7 @@ public class DialConferenceConnectionFailureTest {
     private final String confRoom2 = "confRoom2";
     private String dialConfernceRcml = "<Response><Dial><Conference>"+confRoom2+"</Conference></Dial></Response>";
     @Test
-    public synchronized void testDialConferenceClientsDisconnect() throws InterruptedException {
+    public synchronized void testDialConferenceConnectionFailureCallCleanupTest() throws InterruptedException {
         stubFor(get(urlPathEqualTo("/1111"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -169,7 +170,7 @@ public class DialConferenceConnectionFailureTest {
         assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
         int numOfParticipants = RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2);
         logger.info("Number of participants: "+numOfParticipants);
-        assertEquals(1, numOfParticipants);
+        assertEquals(2, numOfParticipants);
 
         JsonObject metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
         Map<String, Integer> mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
@@ -187,14 +188,10 @@ public class DialConferenceConnectionFailureTest {
         Thread.sleep(5000);
         liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
         liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
-        logger.info("&&&&& LiveCalls: "+liveCalls);
-        logger.info("&&&&& LiveCallsArraySize: "+liveCallsArraySize);
         assertEquals(0, liveCalls);
         assertEquals(0, liveCallsArraySize);
         assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
-        numOfParticipants = RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2);
-        logger.info("Number of participants: "+numOfParticipants);
-        assertEquals(0, numOfParticipants);
+        assertEquals(0, RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2));
 
         metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
         mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialConferenceConnectionFailureTest.java
@@ -1,0 +1,226 @@
+package org.restcomm.connect.testsuite.telephony;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.cafesip.sipunit.SipAssert.assertLastOperationSuccess;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.Map;
+
+import javax.sip.message.Response;
+
+import org.apache.log4j.Logger;
+import org.cafesip.sipunit.SipCall;
+import org.cafesip.sipunit.SipPhone;
+import org.cafesip.sipunit.SipStack;
+import org.jboss.arquillian.container.mss.extension.SipStackTool;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.archive.ShrinkWrapMaven;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.restcomm.connect.commons.Version;
+import org.restcomm.connect.commons.annotations.SequentialClassTests;
+import org.restcomm.connect.testsuite.http.RestcommConferenceTool;
+import org.restcomm.connect.testsuite.tools.MonitoringServiceTool;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.gson.JsonObject;
+
+/**
+ * @author mariafarooq
+ */
+@RunWith(Arquillian.class)
+@Category(value={SequentialClassTests.class})
+public class DialConferenceConnectionFailureTest {
+    private final static Logger logger = Logger.getLogger(DialConferenceConnectionFailureTest.class.getName());
+
+    private static final String version = Version.getVersion();
+    private static final byte[] bytes = new byte[]{118, 61, 48, 13, 10, 111, 61, 117, 115, 101, 114, 49, 32, 53, 51, 54, 53,
+            53, 55, 54, 53, 32, 50, 51, 53, 51, 54, 56, 55, 54, 51, 55, 32, 73, 78, 32, 73, 80, 52, 32, 49, 50, 55, 46, 48, 46,
+            48, 46, 49, 13, 10, 115, 61, 45, 13, 10, 99, 61, 73, 78, 32, 73, 80, 52, 32, 49, 50, 55, 46, 48, 46, 48, 46, 49,
+            13, 10, 116, 61, 48, 32, 48, 13, 10, 109, 61, 97, 117, 100, 105, 111, 32, 54, 48, 48, 48, 32, 82, 84, 80, 47, 65,
+            86, 80, 32, 48, 13, 10, 97, 61, 114, 116, 112, 109, 97, 112, 58, 48, 32, 80, 67, 77, 85, 47, 56, 48, 48, 48, 13, 10};
+    private static final String body = new String(bytes);
+
+    @ArquillianResource
+    URL deploymentUrl;
+
+    private String adminAccountSid = "ACae6e420f425248d6a26948c17a9e2acf";
+    private String adminAuthToken = "77f8c12cc7b8f8423e5c38b035249166";
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(8090); // No-args constructor defaults to port 8080
+
+    private static SipStackTool tool1;
+    private static SipStackTool tool2;
+
+    // Bob is a simple SIP Client. Will not register with Restcomm
+    private SipStack bobSipStack;
+    private SipPhone bobPhone;
+    private String bobContact = "sip:bob@127.0.0.1:5090";
+
+    // George is a simple SIP Client. Will not register with Restcomm
+    private SipStack georgeSipStack;
+    private SipPhone georgePhone;
+    private String georgeContact = "sip:+131313@127.0.0.1:5070";
+
+    private String dialRestcomm = "sip:1111@127.0.0.1:5080";
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        tool1 = new SipStackTool("DialConferenceTool1");
+        tool2 = new SipStackTool("DialConferenceTool3");
+    }
+
+    @Before
+    public void before() throws Exception {
+        bobSipStack = tool1.initializeSipStack(SipStack.PROTOCOL_UDP, "127.0.0.1", "5090", "127.0.0.1:5080");
+        bobPhone = bobSipStack.createSipPhone("127.0.0.1", SipStack.PROTOCOL_UDP, 5080, bobContact);
+
+        georgeSipStack = tool2.initializeSipStack(SipStack.PROTOCOL_UDP, "127.0.0.1", "5070", "127.0.0.1:5080");
+        georgePhone = georgeSipStack.createSipPhone("127.0.0.1", SipStack.PROTOCOL_UDP, 5080, georgeContact);
+    }
+
+    @After
+    public void after() throws Exception {
+        if (bobPhone != null) {
+            bobPhone.dispose();
+        }
+        if (bobSipStack != null) {
+            bobSipStack.dispose();
+        }
+
+        if (georgePhone != null) {
+            georgePhone.dispose();
+        }
+        if (georgeSipStack != null) {
+            georgeSipStack.dispose();
+        }
+        Thread.sleep(3000);
+        wireMockRule.resetRequests();
+        Thread.sleep(4000);
+    }
+
+    private final String confRoom2 = "confRoom2";
+    private String dialConfernceRcml = "<Response><Dial><Conference>"+confRoom2+"</Conference></Dial></Response>";
+    @Test
+    public synchronized void testDialConferenceClientsDisconnect() throws InterruptedException {
+        stubFor(get(urlPathEqualTo("/1111"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody(dialConfernceRcml)));
+
+        final SipCall bobCall = bobPhone.createSipCall();
+        bobCall.initiateOutgoingCall(bobContact, dialRestcomm, null, body, "application", "sdp", null, null);
+        assertLastOperationSuccess(bobCall);
+        assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+        int responseBob = bobCall.getLastReceivedResponse().getStatusCode();
+        assertTrue(responseBob == Response.TRYING || responseBob == Response.RINGING);
+
+        if (responseBob == Response.TRYING) {
+            assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+            assertEquals(Response.RINGING, bobCall.getLastReceivedResponse().getStatusCode());
+        }
+
+        assertTrue(bobCall.waitOutgoingCallResponse(5 * 1000));
+        assertEquals(Response.OK, bobCall.getLastReceivedResponse().getStatusCode());
+        bobCall.sendInviteOkAck();
+        assertTrue(!(bobCall.getLastReceivedResponse().getStatusCode() >= 400));
+
+        final SipCall georgeCall = georgePhone.createSipCall();
+        georgeCall.initiateOutgoingCall(georgeContact, dialRestcomm, null, body, "application", "sdp", null, null);
+        assertLastOperationSuccess(georgeCall);
+        assertTrue(georgeCall.waitOutgoingCallResponse(5 * 1000));
+        int responseGeorge = georgeCall.getLastReceivedResponse().getStatusCode();
+        assertTrue(responseGeorge == Response.TRYING || responseGeorge == Response.RINGING);
+
+        if (responseGeorge == Response.TRYING) {
+            assertTrue(georgeCall.waitOutgoingCallResponse(5 * 1000));
+            assertEquals(Response.RINGING, georgeCall.getLastReceivedResponse().getStatusCode());
+        }
+
+        assertTrue(georgeCall.waitOutgoingCallResponse(5 * 1000));
+        assertEquals(Response.OK, georgeCall.getLastReceivedResponse().getStatusCode());
+        georgeCall.sendInviteOkAck();
+        assertTrue(!(georgeCall.getLastReceivedResponse().getStatusCode() >= 400));
+
+        Thread.sleep(2000);
+
+        int liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
+        int liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
+        logger.info("&&&&& LiveCalls: "+liveCalls);
+        logger.info("&&&&& LiveCallsArraySize: "+liveCallsArraySize);
+        assertEquals(2, liveCalls);
+        assertEquals(2, liveCallsArraySize);
+        assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
+        int numOfParticipants = RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2);
+        logger.info("Number of participants: "+numOfParticipants);
+        assertEquals(1, numOfParticipants);
+
+        JsonObject metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
+        Map<String, Integer> mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
+        int mgcpEndpoints = mgcpResources.get("MgcpEndpoints");
+        int mgcpConnections = mgcpResources.get("MgcpConnections");
+
+        assertTrue(mgcpEndpoints>0);
+        assertTrue(mgcpConnections>0);
+
+        Thread.sleep(3000);
+
+        georgeCall.disconnect();
+        bobCall.disconnect();
+
+        Thread.sleep(5000);
+        liveCalls = MonitoringServiceTool.getInstance().getStatistics(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
+        liveCallsArraySize = MonitoringServiceTool.getInstance().getLiveCallsArraySize(deploymentUrl.toString(), adminAccountSid, adminAuthToken);
+        logger.info("&&&&& LiveCalls: "+liveCalls);
+        logger.info("&&&&& LiveCallsArraySize: "+liveCallsArraySize);
+        assertEquals(0, liveCalls);
+        assertEquals(0, liveCallsArraySize);
+        assertEquals(1, RestcommConferenceTool.getInstance().getConferencesSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken));
+        numOfParticipants = RestcommConferenceTool.getInstance().getParticipantsSize(deploymentUrl.toString(), adminAccountSid, adminAuthToken, confRoom2);
+        logger.info("Number of participants: "+numOfParticipants);
+        assertEquals(0, numOfParticipants);
+
+        metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
+        mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
+        mgcpEndpoints = mgcpResources.get("MgcpEndpoints");
+        mgcpConnections = mgcpResources.get("MgcpConnections");
+
+        assertEquals(0, mgcpEndpoints);
+        assertEquals(0, mgcpConnections);
+    }
+
+    @Deployment(name = "DialConferenceTest", managed = true, testable = false)
+    public static WebArchive createWebArchiveNoGw() {
+        logger.info("Packaging Test App");
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "restcomm.war");
+        final WebArchive restcommArchive = ShrinkWrapMaven.resolver()
+                .resolve("org.restcomm:restcomm-connect.application:war:" + version).withoutTransitivity()
+                .asSingle(WebArchive.class);
+        archive = archive.merge(restcommArchive);
+        archive.delete("/WEB-INF/sip.xml");
+        archive.delete("/WEB-INF/conf/restcomm.xml");
+        archive.delete("/WEB-INF/data/hsql/restcomm.script");
+        archive.addAsWebInfResource("sip.xml");
+        archive.addAsWebInfResource("restcomm-with-failing-mockmedia.xml", "conf/restcomm.xml");
+        archive.addAsWebInfResource("restcomm.script_dialTest_new", "data/hsql/restcomm.script");
+        logger.info("Packaged Test App");
+        return archive;
+    }
+
+}

--- a/restcomm/restcomm.testsuite/src/test/resources/restcomm-with-failing-mockmedia.xml
+++ b/restcomm/restcomm.testsuite/src/test/resources/restcomm-with-failing-mockmedia.xml
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This is free software; you can redistribute it and/or modify it under
+	the terms of the GNU Lesser General Public License as published by the Free
+	Software Foundation; either version 2.1 of the License, or (at your option)
+	any later version. This software is distributed in the hope that it will
+	be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+	Public License for more details. You should have received a copy of the GNU
+	Lesser General Public License along with this software; if not, write to
+	the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston,
+	MA 02110-1301 USA, or see the FSF site: http://www.fsf.org. -->
+<restcomm>
+	<runtime-settings>
+		<!-- The API version that will be used. -->
+		<api-version>2012-04-24</api-version>
+
+		<!-- Try to run RVD workspace projects migration to apply new naming
+			convention and synchronization with database entities. This execution
+			will occurs max one time per Restcomm version. To force a new run,
+			remove the file .version inside RVD workspace. -->
+		<rvd-workspace-migration-enabled>false</rvd-workspace-migration-enabled>
+
+		<!-- The location where the audio prompts are located. -->
+		<prompts-uri>/restcomm/audio</prompts-uri>
+
+		<!-- Cache settings. -->
+		<cache-path>${restcomm:home}/cache</cache-path>
+		<cache-uri>/restcomm/cache</cache-uri>
+
+		<!-- The path where recordings made by the <Record> verb are stored. -->
+		<recordings-path>file://${restcomm:home}/recordings</recordings-path>
+		<recordings-uri>/restcomm/recordings</recordings-uri>
+
+		<!-- The URL to the errors dictionary. -->
+		<error-dictionary-uri>/restcomm/errors</error-dictionary-uri>
+
+		<!-- The IP to use for out-bound SIP REGISTER requests. This is useful
+			when you want to report a different IP than the one RestComm picked by default. -->
+		<external-ip></external-ip>
+
+		<!-- If set to true RestComm will use the To header to determine the destination.
+			If set to false RestComm will use the Request URI to determine the destination. -->
+		<use-to>true</use-to>
+
+		<!-- If set to true Restcomm will use the Local Address (or external address
+			if available) in the host part of the From header for calls to the outbound
+			proxy. Default is False, which means that Restcomm will use outbound proxy
+			for the host part of From header -->
+		<use-local-address>false</use-local-address>
+
+		<!-- If set to true Restcomm will authenticate users and incoming messages
+			from those users -->
+		<authenticate>true</authenticate>
+
+		<!-- Interval time in seconds that Restcomm will send keepalive messages (OPTIONS) to registered clients -->
+		<ping-interval>60</ping-interval>
+
+		<!-- If set to FALSE Restcomm wont normalize phone numbers (prepend +1)
+			when creating an outbound call -->
+		<normalize-numbers-for-outbound-calls>true</normalize-numbers-for-outbound-calls>
+		<!--If set to TRUE Restcomm will use the From address of initial call to
+			proxied calls Caller A dials DID XYZ that is bind to RCML that Dials Number
+			4321. If from-address-to-proxied-calls is TRUE Restcomm will pass callerId
+			A to the created call -->
+		<from-address-to-proxied-calls>true</from-address-to-proxied-calls>
+
+		<!-- Control whether Restcomm will try to patch the Request-URI and SDP
+			for B2BUA sessions with the discovered external IP Address of the peer -->
+		<!-- Default value: true -->
+		<patch-for-nat-b2bua-sessions>true</patch-for-nat-b2bua-sessions>
+
+		<outbound-proxy>
+			<!-- Parameters for primary outbound proxy. -->
+			<outbound-proxy-user></outbound-proxy-user>
+			<outbound-proxy-password></outbound-proxy-password>
+			<outbound-proxy-uri>127.0.0.1:5070</outbound-proxy-uri>
+
+			<!-- Parameters for fallback outbound proxy. -->
+			<fallback-outbound-proxy-user></fallback-outbound-proxy-user>
+			<fallback-outbound-proxy-password></fallback-outbound-proxy-password>
+			<fallback-outbound-proxy-uri>127.0.0.1:5090</fallback-outbound-proxy-uri>
+
+			<!-- When set to true, Restcomm will use the username of the outbound
+				proxy when -->
+			<!-- creating the From header, as the userpart of the sip uri. Example:
+				From: "Alice" <sip:PROXY_USERNAME@PROXY> -->
+			<outboudproxy-user-at-from-header>true</outboudproxy-user-at-from-header>
+			<!-- When set to true, Restcomm will use the original user for the display
+				name of the From header -->
+			<!-- Example: From: "Alice" <sip:PROXY_USERNAME@PROXY> -->
+			<user-at-displayed-name>true</user-at-displayed-name>
+
+			<!-- Allow fallback to backup proxy -->
+			<allow-fallback>true</allow-fallback>
+			<!-- Number of maximum failed calls before switching from primary to the
+				fallback outbound proxy -->
+			<max-failed-calls>20</max-failed-calls>
+			<!-- Allow fallback to Primary proxy in case backup proxy fails also -->
+			<allow-fallback-to-primary>true</allow-fallback-to-primary>
+		</outbound-proxy>
+
+		<telestax-proxy>
+			<enabled>false</enabled>
+			<login>restcomm</login>
+			<password>restcomm</password>
+			<endpoint>restcomm_instance_id</endpoint>
+			<uri>http://127.0.0.1:2080</uri>
+		</telestax-proxy>
+
+		<!-- TelScale USSD Gateway -->
+		<ussd-gateway>
+			<ussd-gateway-uri>127.0.0.1:5090</ussd-gateway-uri>
+			<ussd-gateway-user></ussd-gateway-user>
+			<ussd-gateway-password></ussd-gateway-password>
+		</ussd-gateway>
+
+		<gmlc>
+			<gmlc-uri>http://127.0.0.1:8090/restcomm/gmlc/rest?msisdn=</gmlc-uri> <!-- Change GMLC-IP:port to appropriate value-->
+			<gmlc-user></gmlc-user>
+			<gmlc-password></gmlc-password>
+		</gmlc>
+
+		<!-- Each permission is represented as three columns Domain:Action:Target
+			Possible actions are Create, Read, Modify, Delete. -->
+		<security-roles>
+			<role name="Developer">
+				<permission>RestComm:*:Accounts</permission>
+				<permission>RestComm:*:Applications</permission>
+				<permission>RestComm:*:Announcements</permission>
+				<permission>RestComm:Read:AvailablePhoneNumbers</permission>
+				<permission>RestComm:*:Calls</permission>
+				<permission>RestComm:*:Clients</permission>
+				<permission>RestComm:*:Conferences</permission>
+				<permission>RestComm:Create,Delete,Read:Faxes</permission>
+				<permission>RestComm:*:IncomingPhoneNumbers</permission>
+				<permission>RestComm:Read:Notifications</permission>
+				<permission>RestComm:*:OutgoingCallerIds</permission>
+				<permission>RestComm:Delete,Read:Recordings</permission>
+				<permission>RestComm:Read,Modify:SandBoxes</permission>
+				<permission>RestComm:*:ShortCodes</permission>
+				<permission>RestComm:Read:SmsMessages</permission>
+				<permission>RestComm:Read:Transcriptions</permission>
+				<permission>RestComm:*:OutboundProxies</permission>
+				<permission>RestComm:*:EmailMessages</permission>
+				<permission>RestComm:*:Usage</permission>
+				<permission>RestComm:*:Geolocation</permission>
+			</role>
+			<role name="Unprivileged">
+				<permission>RestComm:Read:Accounts</permission>
+			</role>
+			<role name="Guest"></role>
+		</security-roles>
+	</runtime-settings>
+
+	<!-- Configuration for the VoIP Innovations provisioning API. -->
+	<phone-number-provisioning
+		class="org.restcomm.connect.provisioning.number.vi.VoIPInnovationsNumberProvisioningManager">
+		<callback-urls>
+			<voice url="localhost:5080" method="SIP" />
+			<sms url="localhost:5080" method="SIP" />
+			<fax url="localhost:5080" method="SIP" />
+			<ussd url="localhost:5080" method="SIP" />
+		</callback-urls>
+		<voip-innovations>
+			<login></login>
+			<password></password>
+			<endpoint></endpoint>
+			<uri>https://backoffice.voipinnovations.com/api2.pl</uri>
+		</voip-innovations>
+	</phone-number-provisioning>
+
+	<smtp-notify>
+		<host></host>
+		<user></user>
+		<password></password>
+		<port></port>
+		<!-- Default mail address used to report issues related to Restcomm management,
+		mostly associated with bootstrap executions, like workspace migration, etc. -->
+		<default-email-address></default-email-address>
+	</smtp-notify>
+
+	<smtp-service>
+		<host>
+		</host>
+		<user></user>
+		<password></password>
+		<port></port>
+	</smtp-service>
+
+	<amazon-s3>
+		<enabled>false</enabled>
+		<bucket-name>restcomm-recordings</bucket-name>
+		<folder></folder>
+		<access-key></access-key>
+		<security-key></security-key>
+		<reduced-redundancy>false</reduced-redundancy>
+		<minutes-to-retain-public-url>7</minutes-to-retain-public-url>
+		<remove-original-file>true</remove-original-file>
+	</amazon-s3>
+
+	<!-- Defines how RestComm communicates with the Media Server Control layer.
+		Accepted values: XMS (Dialogic XMS using JSR-309 driver) or RMS (RestComm
+		Media Server using MGCP driver) -->
+	<mscontrol>
+		<compatibility>rms</compatibility>
+		<media-server name="Dialogic XMS" class="com.dialogic.dlg309">
+			<address>127.0.0.1</address>
+			<port>5060</port>
+			<transport>udp</transport>
+			<timeout>5</timeout>
+		</media-server>
+	</mscontrol>
+	<dns-util class="org.restcomm.connect.commons.util.mock.InetAddressMock"/>
+
+	<!-- The media server manager is responsible for managing the media servers
+		in use by RestComm. The default way to control media servers is using the
+		MGCP stack. The MGCP stack MUST have a name and the following parameters:
+		<stack-address> - The local IP address for the MGCP stack. <stack-port> -
+		The local port for the MGCP stack. <remote-address> - The IP address for
+		the media server. <remote-port> - The port for the media server. <external-address>
+		- Sometimes there is interest to use a different address in the SDP than
+		the IP address the media server is reporting. This parameter if set tells
+		RestComm to patch the Connection attribute in the SDP on behalf of the media
+		server to the specified IP address. Note: RestComm will only do NAT resolution
+		when necessary so if your server already has a routable IP address setting
+		this parameter will have no effect. <max-response-time> - In milliseconds
+		the maximum amount of time to wait for a response from the media server before
+		abandoning the request. This does NOT apply to RQNT/NOTIFY request/response. -->
+	<media-server-manager>
+		<mgcp-server class="org.restcomm.connect.mgcp.MockMediaGatewayConferenceLinkCreationError"
+			name="Mobicents Media Server">
+				<local-address>127.0.0.1</local-address>
+				<local-port>2727</local-port>
+				<remote-address>127.0.0.1</remote-address>
+				<remote-port>2427</remote-port>
+				<response-timeout>1500</response-timeout>
+				<!-- <external-address></external-address> -->
+			</mgcp-server>
+		<mrb class="org.restcomm.connect.mrb.MediaResourceBrokerGeneric" name="Community MediaResourceBroker">
+		</mrb>
+	</media-server-manager>
+
+		<!-- Adjust http client behaviour for outgoing requests -->
+	<http-client>
+		<response-timeout>5000</response-timeout>
+		<!-- Control peer certificate verification for https connections. Two modes are supported:
+			'allowall' : Disables peer certificate verification. Use it when testing.
+			'strict' : Fails requests if peer certificate is not trusted. Use it in production. -->
+		<ssl-mode>strict</ssl-mode>
+		<!-- Control whether relative URL should be resolved using hostname instead of IP Address.
+		If for any reason hostname resolution fails, IP Address will be used -->
+		<use-hostname-to-resolve-relative-url>true</use-hostname-to-resolve-relative-url>
+		<!-- Optionally provide the hostname to be used, otherwise Java will try to get the hostname of the machine JVM is running -->
+		<hostname>127.0.0.1</hostname>
+	</http-client>
+
+	<!-- The SMS aggregator is responsible for the handling of SMS messages
+		inside of RestComm. Refer to the org.mobicents.servlet.sip.restcomm.SmsAggregator
+		interface for more information. -->
+	<sms-aggregator class="org.restcomm.connect.sms.SmsService">
+		<outbound-prefix></outbound-prefix>
+		<outbound-endpoint>127.0.0.1:5090</outbound-endpoint>
+	</sms-aggregator>
+
+	<!-- by default activateSmppConnection is set to false -->
+
+	<smpp class="org.restcomm.connect.sms.smpp.SmppService" activateSmppConnection ="false">
+		<connections>
+			<connection activateAddressMapping="false" sourceAddressMap="" destinationAddressMap="" tonNpiValue="1">
+				<!-- Name must be unique for each connection -->
+				<name>test</name>
+				<systemid>test</systemid>
+				<peerip>127.0.0.1</peerip>
+				<peerport>2776</peerport>
+				<bindtype>TRANSCEIVER</bindtype>
+				<!-- These are optional params -->
+				<password>test</password>
+				<systemtype>sms</systemtype>
+				<!-- byte value for interface version 0x34 is 3.4, 0x33 is 3.3 and 0x50
+					is 5.0 -->
+				<interfaceversion>0x34</interfaceversion>
+				<ton>-1</ton>
+				<npi>-1</npi>
+				<range></range>
+				<!-- Default value is 1. The window size is the amount of unacknowledged
+					requests that are permitted to be outstanding/unacknowledged at any given
+					time. If more requests are added, the underlying stack will throw an exception. -->
+				<windowsize>1</windowsize>
+				<!-- Default value is 60000 milli seconds. This parameter is used to
+					specify the time to wait until a slot opens up in the 'sendWindow'. -->
+				<windowwaittimeout>60000</windowwaittimeout>
+				<!-- BIND request must be sent within configured timeout in ms -->
+				<connecttimeout>10000</connecttimeout>
+				<!-- Set the amount of time to wait for an endpoint to respond to a request
+					before it expires. Defaults to disabled (-1). -->
+				<requestexpirytimeout>30000</requestexpirytimeout>
+				<!-- Sets the amount of time between executions of monitoring the window
+					for requests that expire. It's recommended that this generally either matches
+					or is half the value of requestExpiryTimeout. Therefore, at worst a request
+					would could take up 1.5X the requestExpiryTimeout to clear out. -->
+				<windowmonitorinterval>15000</windowmonitorinterval>
+				<logbytes>true</logbytes>
+				<countersenabled>true</countersenabled>
+				<!-- Default value is 30000 milli seconds. When SMPP connects to a remote
+					server, it sends an 'ENQUIRE_LINK' after every configured enquire-link-delay.
+					If no response received for 3 consecutive requests, connection will be killed
+					and attempted to connect again -->
+				<enquirelinkdelay>30000</enquirelinkdelay>
+			</connection>
+		</connections>
+	</smpp>
+
+	<!-- The Fax Service is used to send and receive faxes on behalf of RestComm. -->
+	<fax-service class="org.restcomm.connect.fax.InterfaxService">
+		<user></user>
+		<password></password>
+	</fax-service>
+
+	<!-- The Speech Recognizer is responsible for turning speech in to text. -->
+	<speech-recognizer class="org.restcomm.connect.asr.ISpeechAsr">
+		<api-key production="false"></api-key>
+	</speech-recognizer>
+
+	<speech-synthesizer active="voicerss"/>
+
+	<!-- The Speech Synthesizer is responsible for turning text in to speech for play back by the media gateway. -->
+	<acapela class="org.restcomm.connect.tts.acapela.AcapelaSpeechSynthesizer">
+		<service-root>http://vaas.acapela-group.com/Services/Synthesizer</service-root>
+		<application></application>
+		<login></login>
+		<password></password>
+		<speakers>
+			<belgium-french> <female>justine8k</female> <male></male> </belgium-french>
+			<brazilian-portuguese> <female>marcia8k</female> <male></male> </brazilian-portuguese>
+			<british-english> <female>rachel8k</female> <male>graham8k</male> </british-english>
+			<canadian-french> <female>louise8k</female> <male></male> </canadian-french>
+			<czech> <female>eliska8k</female> <male></male> </czech>
+			<danish> <female>mette8k</female><male>rasmus8k</male></danish>
+			<english> <female>heather8k</female> <male>ryan8k</male> </english>
+			<finnish> <female>sanna8k</female> <male></male> </finnish>
+			<french> <female>claire8k</female> <male>bruno8k</male> </french>
+			<german> <female>sarah8k</female> <male>klaus8k</male> </german>
+			<greek> <female></female> <male>dimitris8k</male> </greek>
+			<italian> <female>chiara8k</female> <male>vittorio8k</male> </italian>
+			<netherlands-dutch> <female>jasmijn8k</female> <male>daan8k</male> </netherlands-dutch>
+			<norwegian> <female>kari8k</female> <male>olav8k</male> </norwegian>
+			<polish><female>ania8k</female> <male></male> </polish>
+			<portuguese> <female>celia8k</female><male></male> </portuguese>
+			<russian> <female>alyona8k</female> <male></male></russian>
+			<saudi-arabia-arabic> <female>salma8k</female> <male>mehdi8k</male></saudi-arabia-arabic>
+			<spain-catalan> <female>laia8k</female> <male></male> </spain-catalan>
+			<spanish> <female>maria8k</female> <male>antonio8k</male></spanish>
+			<swedish> <female>elin8k</female> <male>emil8k</male> </swedish>
+			<turkish> <female>ipek8k</female> <male></male> </turkish>
+		</speakers>
+	</acapela>
+
+	<voicerss class="org.restcomm.connect.tts.voicerss.VoiceRSSSpeechSynthesizer">
+		<service-root>http://api.voicerss.org</service-root>
+		<apikey></apikey>
+		<languages>
+			<catalan>ca-es</catalan>
+			<chinese-china>zh-cn</chinese-china>
+			<chinese-hongkong>zh-hk</chinese-hongkong>
+			<chinese-taiwan>zh-tw</chinese-taiwan>
+			<danish>da-dk</danish>
+			<dutch>nl-nl</dutch>
+			<english-australia>en-au</english-australia>
+			<english-canada>en-ca</english-canada>
+			<english-greatbritain>en-gb</english-greatbritain>
+			<english-india>en-in</english-india>
+			<english-us>en-us</english-us>
+			<finish>fi-fi</finish>
+			<french-canada>fr-ca</french-canada>
+			<french-france>fr-fr</french-france>
+			<german>de-de</german>
+			<italian>it-it</italian>
+			<japanese>ja-jp</japanese>
+			<korean>ko-kr</korean>
+			<norwegian>nb-no</norwegian>
+			<polish>pl-pl</polish>
+			<portuguese-brasil>pt-br</portuguese-brasil>
+			<portuguese-portugal>pt-pt</portuguese-portugal>
+			<russian>ru-ru</russian>
+			<spanish-mexico>es-mx</spanish-mexico>
+			<spanish-spain>es-es</spanish-spain>
+			<swedish>sv-se</swedish>
+		</languages>
+	</voicerss>
+
+
+	<!-- AT&T Speech Synthesizer plugin -->
+	<!-- <speech-synthesizer class="org.restcomm.connect.tts.att.AttSpeechSynthesizer">
+		<host>127.0.0.1</host> <port>7000</port> <tts-client-directory></tts-client-directory>
+		<verbose-output>false</verbose-output> <speakers> <english> <female>crystal8</female>
+		<male>mike8</male> </english> <english-uk> <female>audrey8</female> <male>charles8</male>
+		</english-uk> <spanish> <female>rosa8</female> <male>alberto8</male> </spanish>
+		<french> <female>juliette8</female> <male>alain8</male> </french> <canadian-french>
+		<male>arnaud8</male> </canadian-french> <german> <female>klara8</female>
+		<male>reiner8</male> </german> <italian> <female>francesca8</female> <male>giovanni8</male>
+		</italian> <brazilian-portuguese> <female>marina8</female> <male>tiago8</male>
+		</brazilian-portuguese> </speakers> </speech-synthesizer> -->
+</restcomm>


### PR DESCRIPTION
**Current Scenario**

- Call tries to join a conference:
- MS Controller will try to join call and conference endpoints
- If (for some reason) this join fails at RMS side:
-- Call stays in `joining` state forever and does not get cleaned

**Expected Scenario**
- Instead call should complete and clean accordingly.