### PR TITLE
Fix mediaserver connectivity issues on docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       ## =============================== IMPORTANT!!    While most of the below defaults should be fine, YOU PROBABLY NEED TO CHANGE THIS!!
       RCBCONF_STATIC_ADDRESS: 127.0.0.1   # YOUR LOCAL IP ADDRESS GOES HERE.
+      RMSCONF_EXTERNAL_ADDRESS: 127.0.0.1  # YOUR LOCAL IP ADDRESS GOES HERE.
       ## =============================== IMPORTANT ========================================================================================
 
       # ENVCONFURL: https://raw.githubusercontent.com/RestComm/Restcomm-Docker/master/env_files/restcomm_env_locally.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,8 @@ services:
       RCADVCONF_TRUSTSTORE_ALIAS: restcomm
 
       #Functional configuration. Make sure these match the published port range in the `ports` section below.
-      RMSCONF_MEDIASERVER_LOWEST_PORT: 65000
-      RMSCONF_MEDIASERVER_HIGHEST_PORT: 65050
+      RMSCONF_MEDIA_LOW_PORT: 65000
+      RMSCONF_MEDIA_HIGH_PORT: 65050
 
       #RestComm Port configuration. Make sure these match the published ports in the `ports` section below.
       RCBCONF_SIP_PORT_UDP: 5080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       RCBCONF_STATIC_ADDRESS: 127.0.0.1   # YOUR LOCAL IP ADDRESS GOES HERE.
       ## =============================== IMPORTANT ========================================================================================
 
-      ENVCONFURL: https://raw.githubusercontent.com/RestComm/Restcomm-Docker/master/env_files/restcomm_env_locally.sh
+      # ENVCONFURL: https://raw.githubusercontent.com/RestComm/Restcomm-Docker/master/env_files/restcomm_env_locally.sh
       # REPOUSR: Username for `ENVCONFURL` if Authentication needed.
       # REPOPWD: Password for `ENVCONFURL` if Authentication needed.
 


### PR DESCRIPTION
On macOS (at least) the SIP client fails to connect to the Restcomm Media Server, when running with `docker compose up` as the IP address the RMS scripts pick up is the docker one (e.g. `172.24.0.2`) and that's not accessible from the host. 

The extra env var allows setting a routable IP address which a SIP client can use to connect to both Restcomm Connect, as well as the Media Server. 

A special thanks to @hrosa for the help debugging this! <3

/cc @agafox: I believe this still doesn't work with `127.0.0.1` but I think this brings us a step closer. 