### PR TITLE
fixes restcom1757 allowing to override LINK/UNLINK methods

### DIFF
--- a/restcomm/restcomm.http/src/main/java/org/restcomm/connect/http/ProfileJsonEndpoint.java
+++ b/restcomm/restcomm.http/src/main/java/org/restcomm/connect/http/ProfileJsonEndpoint.java
@@ -46,6 +46,8 @@ import static org.restcomm.connect.http.security.AccountPrincipal.SUPER_ADMIN_RO
 @Singleton
 public class ProfileJsonEndpoint extends ProfileEndpoint {
 
+    private static final String OVERRIDE_HDR = "X-HTTP-Method-Override";
+
     @GET
     @Produces(APPLICATION_JSON)
     public Response getProfilesAsJson(@Context UriInfo info) {
@@ -69,9 +71,21 @@ public class ProfileJsonEndpoint extends ProfileEndpoint {
 
     @Path("/{profileSid}")
     @PUT
-    @Consumes({PROFILE_CONTENT_TYPE,MediaType.APPLICATION_JSON})
+    @Consumes({PROFILE_CONTENT_TYPE, MediaType.APPLICATION_JSON})
     public Response updateProfileAsJson(@PathParam("profileSid") final String profileSid,
-            InputStream body, @Context UriInfo info) {
+            InputStream body, @Context UriInfo info,
+            @Context HttpHeaders headers) {
+        if (headers.getRequestHeader(OVERRIDE_HDR) != null
+                && headers.getRequestHeader(OVERRIDE_HDR).size() > 0) {
+            String overrideHdr = headers.getRequestHeader(OVERRIDE_HDR).get(0);
+            switch (overrideHdr) {
+                case "LINK":
+                    return linkProfile(profileSid, headers, info);
+                case "UNLINK":
+                    return unlinkProfile(profileSid, headers);
+
+            }
+        }
         return updateProfile(profileSid, body, info);
     }
 

--- a/restcomm/restcomm.testsuite/src/main/java/org/restcomm/connect/testsuite/http/RestcommProfilesTool.java
+++ b/restcomm/restcomm.testsuite/src/main/java/org/restcomm/connect/testsuite/http/RestcommProfilesTool.java
@@ -19,11 +19,13 @@ import java.util.logging.Logger;
 import javax.ws.rs.core.MediaType;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicHeader;
 import org.restcomm.connect.testsuite.http.util.HttpLink;
 import org.restcomm.connect.testsuite.http.util.HttpUnLink;
+
 
 /**
  * @author maria farooq
@@ -322,6 +324,18 @@ public class RestcommProfilesTool {
         return response;
     }
 
+    public HttpResponse linkProfileWithOverride(String deploymentUrl, String operatorUsername, String operatorAuthtoken, String profileSid, String targetResourceSid, AssociatedResourceType type) throws IOException, URISyntaxException {
+        String url = getProfilesEndpointUrl(deploymentUrl) + "/" + profileSid;
+
+        HttpPut request = new HttpPut(url);
+        addLinkUnlinkRequiredHeaders(request, deploymentUrl, operatorUsername, operatorAuthtoken, profileSid, targetResourceSid, type);
+        request.addHeader("X-HTTP-Method-Override", "LINK");
+        final DefaultHttpClient client = new DefaultHttpClient();
+        final HttpResponse response = client.execute(request);
+        logger.info("response is here: " + response);
+        return response;
+    }
+
     /**
      * unlink a profile from a target resource
      *
@@ -345,6 +359,18 @@ public class RestcommProfilesTool {
         logger.info("response is here: " + response);
         return response;
     }
+
+    public HttpResponse unLinkProfileWithOverride(String deploymentUrl, String operatorUsername, String operatorAuthtoken, String profileSid, String targetResourceSid, AssociatedResourceType type) throws IOException, URISyntaxException {
+        String url = getProfilesEndpointUrl(deploymentUrl) + "/" + profileSid;
+
+        HttpPut request = new HttpPut(url);
+        addLinkUnlinkRequiredHeaders(request, deploymentUrl, operatorUsername, operatorAuthtoken, profileSid, targetResourceSid, type);
+        request.addHeader("X-HTTP-Method-Override", "UNLINK");
+        final DefaultHttpClient client = new DefaultHttpClient();
+        final HttpResponse response = client.execute(request);
+        logger.info("response is here: " + response);
+        return response;
+}
 
     /**
      * @param request

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/http/ProfilesEndpointTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/http/ProfilesEndpointTest.java
@@ -313,7 +313,7 @@ public class ProfilesEndpointTest extends EndpointTest {
 		/*
 		 * link a profile to an account
 		 */
-    	HttpResponse response = RestcommProfilesTool.getInstance().linkProfile(deploymentUrl.toString(), SUPER_ADMIN_ACCOUNT_SID, AUTH_TOKEN, DEFAULT_PROFILE_SID, SUPER_ADMIN_ACCOUNT_SID, RestcommProfilesTool.AssociatedResourceType.ACCOUNT);
+    	HttpResponse response = RestcommProfilesTool.getInstance().linkProfileWithOverride(deploymentUrl.toString(), SUPER_ADMIN_ACCOUNT_SID, AUTH_TOKEN, DEFAULT_PROFILE_SID, SUPER_ADMIN_ACCOUNT_SID, RestcommProfilesTool.AssociatedResourceType.ACCOUNT);
     	logger.info("HttpResponse: "+response);
     	assertEquals(200, response.getStatusLine().getStatusCode());
 
@@ -334,7 +334,7 @@ public class ProfilesEndpointTest extends EndpointTest {
     	/*
 		 * unlink a profile from an account
 		 */
-    	response = RestcommProfilesTool.getInstance().unLinkProfile(deploymentUrl.toString(), SUPER_ADMIN_ACCOUNT_SID, AUTH_TOKEN, DEFAULT_PROFILE_SID, SUPER_ADMIN_ACCOUNT_SID, RestcommProfilesTool.AssociatedResourceType.ACCOUNT);
+    	response = RestcommProfilesTool.getInstance().unLinkProfileWithOverride(deploymentUrl.toString(), SUPER_ADMIN_ACCOUNT_SID, AUTH_TOKEN, DEFAULT_PROFILE_SID, SUPER_ADMIN_ACCOUNT_SID, RestcommProfilesTool.AssociatedResourceType.ACCOUNT);
     	logger.info("HttpResponse: "+response);
     	assertEquals(200, response.getStatusLine().getStatusCode());
 


### PR DESCRIPTION
**What this PR does / why we need it**:
allows overriding LINK/UNLINK for nonCompliant clients
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
