### PR TITLE
[WIP] Fixed media playback issue on MacOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,16 @@ services:
 
     environment:
       ## =============================== IMPORTANT!!    While most of the below defaults should be fine, YOU PROBABLY NEED TO CHANGE THIS!!
-      RCBCONF_STATIC_ADDRESS: 127.0.0.1   # YOUR LOCAL IP ADDRESS GOES HERE.
+      
+      ### Defaults for Docker @ macOS, go with the below, instead. Please note you'll need Docker version > 17.12 for `docker.for.mac.localhost` to work.
+      RCBCONF_STATIC_ADDRESS: docker.for.mac.localhost
       RMSCONF_EXTERNAL_ADDRESS: 127.0.0.1  # YOUR LOCAL IP ADDRESS GOES HERE.
+      RCBCONF_HOSTNAME: docker.for.mac.localhost
+
+      ### Defaults for Docker @ Linux. Please also ensure to enable `network_mode: "host"` below.
+      #RCBCONF_STATIC_ADDRESS: 127.0.0.1 
+      #RMSCONF_EXTERNAL_ADDRESS: 127.0.0.1
+
       ## =============================== IMPORTANT ========================================================================================
 
       # ENVCONFURL: https://raw.githubusercontent.com/RestComm/Restcomm-Docker/master/env_files/restcomm_env_locally.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
On Docker @ macOS calling the default +1234 from the WebRTC demo resulted in no audio being played back in the browser.
The addition of `RCBCONF_HOSTNAME` environment variable together with the use of `docker.for.mac.localhost` (instead! of the local network IP address) resolves the issue.

**Which issue(s) this PR fixes** 
Fixes #2778 

**Special notes for your reviewer**:
please don't merge just yet - pending verification on linux.

To verify, you should comment out the Mac-oriented values in the `docker-compose.yml` and uncomment the linux-oriented ones. Then try calling +1234 from Olympus and see if you hear back the audio. 