### PR TITLE
MySQL connections don't recover after MySQL restart, with single DB host

### DIFF
--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-mysql.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-mysql.sh
@@ -110,6 +110,12 @@ else
         \                        <prepared-statement-cache-size>100</prepared-statement-cache-size> \
         \                        <share-prepared-statements/> \
         \                    </statement> \
+        \                    <validation> \
+        \                       <background-validation>true</background-validation> \
+        \                       <valid-connection-checker class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker"></valid-connection-checker> \
+        \                       <exception-sorter class-name="org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter"></exception-sorter> \
+        \                       <check-valid-connection-sql>select 1</check-valid-connection-sql> \
+        \                   </validation> \
         \                </datasource>' $STANDALONE_SIP > $STANDALONE_SIP.bak
             mv $STANDALONE_SIP.bak $STANDALONE_SIP
    fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes RestComm more stable/resiliant when running against a single MySQL server

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #2856

**Special notes for your reviewer**:
Apologies for not creating a branch or including the issue number in the commit. Was such a minor change I committed it without checking the process.