### PR TITLE
RESTCOM-1856: Allow specific inbound and outbound SMPP encoding

### DIFF
--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-restcomm.sh
@@ -492,6 +492,8 @@ configSMPPAccount() {
 	peerPort="$6"
 	sourceMap="$7"
 	destinationMap="$8"
+	inboundEncoding="$9"
+	outboundEncoding="${10}"
 
 
 	sed -i "s|<smpp class=\"org.restcomm.connect.sms.smpp.SmppService\" activateSmppConnection =\".*\">|<smpp class=\"org.restcomm.connect.sms.smpp.SmppService\" activateSmppConnection =\"$activate\">|g" $FILE
@@ -528,6 +530,13 @@ configSMPPAccount() {
 		}" $FILE
 
         sed -i "s|<connection activateAddressMapping=\"false\" sourceAddressMap=\"\" destinationAddressMap=\"\" tonNpiValue=\"1\">|<connection activateAddressMapping=\"false\" sourceAddressMap=\"${sourceMap}\" destinationAddressMap=\"${destinationMap}\" tonNpiValue=\"1\">|" $FILE
+
+        if [ ! -z "${inboundEncoding}" ]; then
+            xmlstarlet ed -L -P -u  "/restcomm/smpp/connections/connection/inboundencoding" -v $inboundEncoding $FILE
+        fi
+        if [ ! -z "${outboundEncoding}" ]; then
+            xmlstarlet ed -L -P -u  "/restcomm/smpp/connections/connection/outboundencoding" -v $outboundEncoding $FILE
+        fi
 		echo 'Configured SMPP Account Details'
 
 	else
@@ -560,6 +569,10 @@ configSMPPAccount() {
 		}" $FILE
 
         sed -i "s|<connection activateAddressMapping=\"false\" sourceAddressMap=\"\" destinationAddressMap=\"\" tonNpiValue=\"1\">|<connection activateAddressMapping=\"false\" sourceAddressMap=\"\" destinationAddressMap=\"\" tonNpiValue=\"1\">|" $FILE
+
+        xmlstarlet ed -L -P -u  "/restcomm/smpp/connections/connection/inboundencoding" -v "" $FILE
+        xmlstarlet ed -L -P -u  "/restcomm/smpp/connections/connection/outboundencoding" -v "" $FILE
+
 		echo 'Configured SMPP Account Details'
 	fi
 }
@@ -880,7 +893,7 @@ configSpeechRecognizer "$ISPEECH_KEY"
 configSpeechSynthesizers
 configTelestaxProxy "$ACTIVE_PROXY" "$TP_LOGIN" "$TP_PASSWORD" "$INSTANCE_ID" "$PROXY_IP" "$SITE_ID"
 configMediaServerManager "$BIND_ADDRESS" "$MS_ADDRESS" "$MEDIASERVER_EXTERNAL_ADDRESS"
-configSMPPAccount "$SMPP_ACTIVATE" "$SMPP_SYSTEM_ID" "$SMPP_PASSWORD" "$SMPP_SYSTEM_TYPE" "$SMPP_PEER_IP" "$SMPP_PEER_PORT" "$SMPP_SOURCE_MAP" "$SMPP_DEST_MAP"
+configSMPPAccount "$SMPP_ACTIVATE" "$SMPP_SYSTEM_ID" "$SMPP_PASSWORD" "$SMPP_SYSTEM_TYPE" "$SMPP_PEER_IP" "$SMPP_PEER_PORT" "$SMPP_SOURCE_MAP" "$SMPP_DEST_MAP" "$SMPP_INBOUND_ENCODING" "$SMPP_OUTBOUND_ENCODING"
 configRestCommURIs
 updateRecordingsPath
 configHypertextPort

--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/restcomm.conf
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/restcomm.conf
@@ -55,6 +55,8 @@ SMPP_PEER_IP=''	        #use IP or DNS name of peer SMPP server
 SMPP_PEER_PORT=''
 SMPP_SOURCE_MAP=''
 SMPP_DEST_MAP=''
+SMPP_INBOUND_ENCODING=''
+SMPP_OUTBOUND_ENCODING=''
 
 # DID Provision provider variable declarations
 PROVISION_PROVIDER=''               # values: VI (VoipInnovation), BW (Bandwidth), NX (Nexmo), VB (Voxbone)

--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/conf/restcomm.xml
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/conf/restcomm.xml
@@ -670,6 +670,11 @@
 					If no response received for 3 consecutive requests, connection will be killed
 					and attempted to connect again -->
 				<enquirelinkdelay>30000</enquirelinkdelay>
+				<!-- when no values are set, default value from code is UTF-8-->
+				<!-- 
+				<incomingencoding>UTF-8</incomingencoding>
+				<outgoingencoding>GSM7</outgoingencoding>
+				 -->
 			</connection>
 		</connections>
 	</smpp>

--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/conf/restcomm.xml
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/conf/restcomm.xml
@@ -671,9 +671,9 @@
 					and attempted to connect again -->
 				<enquirelinkdelay>30000</enquirelinkdelay>
 				<!-- when no values are set, default value from code is UTF-8-->
-				<!-- 
-				<incomingencoding>UTF-8</incomingencoding>
-				<outgoingencoding>GSM7</outgoingencoding>
+				<!--
+				<inboundencoding>UTF-8</inboundencoding>
+				<outboundencoding>UTF-8</outboundencoding>
 				 -->
 			</connection>
 		</connections>

--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/conf/restcomm.xml
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/conf/restcomm.xml
@@ -670,11 +670,10 @@
 					If no response received for 3 consecutive requests, connection will be killed
 					and attempted to connect again -->
 				<enquirelinkdelay>30000</enquirelinkdelay>
-				<!-- when no values are set, default value from code is UTF-8-->
-				<!--
-				<inboundencoding>UTF-8</inboundencoding>
-				<outboundencoding>UTF-8</outboundencoding>
-				 -->
+				<!-- when no values are set, default value from code is MODIFIED-UTF8 inbound, GSM7 for outbound-->
+				<inboundencoding/>
+				<outboundencoding/>
+
 			</connection>
 		</connections>
 	</smpp>

--- a/restcomm/restcomm.docs/sources-asciidoc/src/main/asciidoc/configuration/Restcomm- Automatic Configuration Options.adoc
+++ b/restcomm/restcomm.docs/sources-asciidoc/src/main/asciidoc/configuration/Restcomm- Automatic Configuration Options.adoc
@@ -75,6 +75,8 @@ SMPP_PEER_IP=''	#use IP or DNS name of peer SMPP server
 SMPP_PEER_PORT=''
 SMPP_SOURCE_MAP=''
 SMPP_DEST_MAP=''
+SMPP_INBOUND_ENCODING=''
+SMPP_OUTBOUND_ENCODING=''
 ----
 
 * Section *#Restcomm DID provider integration*.

--- a/restcomm/restcomm.http/src/main/java/org/restcomm/connect/http/client/HttpRequestDescriptor.java
+++ b/restcomm/restcomm.http/src/main/java/org/restcomm/connect/http/client/HttpRequestDescriptor.java
@@ -56,6 +56,7 @@ public final class HttpRequestDescriptor {
         }
         final String query = uri.getQuery();
         if (query != null) {
+            //FIXME:should we externalize RVD encoding default?
             final List<NameValuePair> other = URLEncodedUtils.parse(uri, "UTF-8");
             parameters.addAll(other);
         }
@@ -104,6 +105,7 @@ public final class HttpRequestDescriptor {
     }
 
     public String getParametersAsString() {
+        //FIXME:should we externalize RVD encoding default?
         return URLEncodedUtils.format(parameters, "UTF-8");
     }
 

--- a/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/Smpp.java
+++ b/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/Smpp.java
@@ -1,5 +1,7 @@
 package org.restcomm.connect.sms.smpp;
 
+import org.apache.log4j.Logger;
+
 import com.cloudhopper.commons.charset.Charset;
 import com.cloudhopper.commons.charset.CharsetUtil;
 import com.cloudhopper.smpp.SmppBindType;
@@ -13,7 +15,10 @@ import com.cloudhopper.smpp.type.Address;
  */
 public class Smpp {
 
-    private static final String DEFAULT_SMPP_ENCODING = "UTF-8";
+    private static final Logger logger = Logger.getLogger(Smpp.class);
+
+    private static final String DEFAULT_SMPP_INBOUND_ENCODING = "MODIFIED-UTF8";
+    private static final String DEFAULT_SMPP_OUTBOUND_ENCODING = "GSM7";
     private String name;
     private String systemId;
     private String peerIp;
@@ -51,7 +56,7 @@ public class Smpp {
     public Smpp(String name, String systemId, String peerIp, int peerPort, SmppBindType smppBindType, String password,
             String systemType, byte interfaceVersion, Address address, long connectTimeout, int windowSize,
             long windowWaitTimeout, long requestExpiryTimeout, long windowMonitorInterval, boolean countersEnabled,
-            boolean logBytes, long enquireLinkDelay, String incomingCharacterEncoding, String outgoingCharacterEncoding) {
+            boolean logBytes, long enquireLinkDelay, String inboundCharacterEncoding, String outboundCharacterEncoding) {
         super();
         this.name = name;
         this.systemId = systemId;
@@ -71,14 +76,20 @@ public class Smpp {
         this.logBytes = logBytes;
         this.enquireLinkDelay = enquireLinkDelay;
         try {
-            this.inboundCharacterEncoding = CharsetUtil.map(incomingCharacterEncoding);
+            this.inboundCharacterEncoding = CharsetUtil.map(inboundCharacterEncoding);
         } catch (Exception e) {
-            this.inboundCharacterEncoding = CharsetUtil.map(DEFAULT_SMPP_ENCODING);
+            this.inboundCharacterEncoding = CharsetUtil.map(DEFAULT_SMPP_INBOUND_ENCODING);
+            if(logger.isInfoEnabled()) {
+                logger.info("Charset " + inboundCharacterEncoding + " does not exist. Inbound encoding is set to default " + DEFAULT_SMPP_INBOUND_ENCODING + "\n" + e.getMessage());
+            }
         }
         try {
-            this.outboundCharacterEncoding = CharsetUtil.map(outgoingCharacterEncoding);
+            this.outboundCharacterEncoding = CharsetUtil.map(outboundCharacterEncoding);
         } catch (Exception e) {
-            this.outboundCharacterEncoding = CharsetUtil.map(DEFAULT_SMPP_ENCODING);
+            this.outboundCharacterEncoding = CharsetUtil.map(DEFAULT_SMPP_OUTBOUND_ENCODING);
+            if(logger.isInfoEnabled()) {
+                logger.info("Charset " + outboundCharacterEncoding+ " does not exist. Outbound encoding is set to default " + DEFAULT_SMPP_OUTBOUND_ENCODING + "\n" + e.getMessage());
+            }
         }
     }
 

--- a/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/Smpp.java
+++ b/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/Smpp.java
@@ -1,5 +1,7 @@
 package org.restcomm.connect.sms.smpp;
 
+import com.cloudhopper.commons.charset.Charset;
+import com.cloudhopper.commons.charset.CharsetUtil;
 import com.cloudhopper.smpp.SmppBindType;
 import com.cloudhopper.smpp.impl.DefaultSmppSession;
 import com.cloudhopper.smpp.type.Address;
@@ -11,6 +13,7 @@ import com.cloudhopper.smpp.type.Address;
  */
 public class Smpp {
 
+    private static final String DEFAULT_SMPP_ENCODING = "UTF-8";
     private String name;
     private String systemId;
     private String peerIp;
@@ -37,6 +40,9 @@ public class Smpp {
 
     private long enquireLinkDelay;
 
+    private Charset inboundCharacterEncoding;
+    private Charset outboundCharacterEncoding;
+
     // not used as of today, but later we can allow users to stop each SMPP
     private boolean started = true;
 
@@ -45,7 +51,7 @@ public class Smpp {
     public Smpp(String name, String systemId, String peerIp, int peerPort, SmppBindType smppBindType, String password,
             String systemType, byte interfaceVersion, Address address, long connectTimeout, int windowSize,
             long windowWaitTimeout, long requestExpiryTimeout, long windowMonitorInterval, boolean countersEnabled,
-            boolean logBytes, long enquireLinkDelay) {
+            boolean logBytes, long enquireLinkDelay, String incomingCharacterEncoding, String outgoingCharacterEncoding) {
         super();
         this.name = name;
         this.systemId = systemId;
@@ -64,6 +70,16 @@ public class Smpp {
         this.countersEnabled = countersEnabled;
         this.logBytes = logBytes;
         this.enquireLinkDelay = enquireLinkDelay;
+        try {
+            this.inboundCharacterEncoding = CharsetUtil.map(incomingCharacterEncoding);
+        } catch (Exception e) {
+            this.inboundCharacterEncoding = CharsetUtil.map(DEFAULT_SMPP_ENCODING);
+        }
+        try {
+            this.outboundCharacterEncoding = CharsetUtil.map(outgoingCharacterEncoding);
+        } catch (Exception e) {
+            this.outboundCharacterEncoding = CharsetUtil.map(DEFAULT_SMPP_ENCODING);
+        }
     }
 
     public String getName() {
@@ -202,6 +218,13 @@ public class Smpp {
         this.enquireLinkDelay = enquireLinkDelay;
     }
 
+    public Charset getInboundDefaultEncoding() {
+        return inboundCharacterEncoding;
+    }
+    public Charset getOutboundDefaultEncoding() {
+        return outboundCharacterEncoding;
+    }
+
     public boolean isStarted() {
         return started;
     }
@@ -228,7 +251,10 @@ public class Smpp {
                 + ", interfaceVersion=" + interfaceVersion + ", address=" + address + ", connectTimeout=" + connectTimeout
                 + ", windowSize=" + windowSize + ", windowWaitTimeout=" + windowWaitTimeout + ", requestExpiryTimeout="
                 + requestExpiryTimeout + ", windowMonitorInterval=" + windowMonitorInterval + ", countersEnabled="
-                + countersEnabled + ", logBytes=" + logBytes + ", enquireLinkDelay=" + enquireLinkDelay + "]";
+                + countersEnabled + ", logBytes=" + logBytes + ", enquireLinkDelay=" + enquireLinkDelay
+                + ", inboundCharacterEncoding=" + inboundCharacterEncoding.toString()
+                + ", outboundCharacterEncoding=" + outboundCharacterEncoding.toString()
+                + "]";
     }
 
     @Override
@@ -255,5 +281,4 @@ public class Smpp {
             return false;
         return true;
     }
-
 }

--- a/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppMessageHandler.java
+++ b/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppMessageHandler.java
@@ -66,6 +66,7 @@ import org.restcomm.connect.telephony.api.FeatureAccessRequest;
 import org.restcomm.smpp.parameter.TlvSet;
 
 import com.cloudhopper.commons.charset.CharsetUtil;
+import com.cloudhopper.smpp.SmppConstants;
 import com.cloudhopper.smpp.pdu.SubmitSm;
 import com.cloudhopper.smpp.tlv.Tlv;
 import com.cloudhopper.smpp.type.Address;
@@ -357,11 +358,11 @@ public class SmppMessageHandler extends RestcommUntypedActor {
         submit0.setSourceAddress(new Address((byte) smppTonNpiValue, (byte) smppTonNpiValue, request.getSmppFrom()));
         submit0.setDestAddress(new Address((byte) smppTonNpiValue, (byte) smppTonNpiValue, request.getSmppTo()));
         if (CharsetUtil.CHARSET_UCS_2 == request.getSmppEncoding()) {
-            submit0.setDataCoding(DataCoding.DATA_CODING_UCS2);
+            submit0.setDataCoding(SmppConstants.DATA_CODING_UCS2);
             textBytes = CharsetUtil.encode(request.getSmppContent(), CharsetUtil.CHARSET_UCS_2);
         } else {
-            submit0.setDataCoding(DataCoding.DATA_CODING_GSM7);
-            textBytes = CharsetUtil.encode(request.getSmppContent(), request.getSmppEncoding());
+            submit0.setDataCoding(SmppConstants.DATA_CODING_DEFAULT);
+            textBytes = CharsetUtil.encode(request.getSmppContent(), SmppClientOpsThread.getOutboundDefaultEncoding());
         }
 
         //TODO reverted from https://telestax.atlassian.net/browse/RESTCOMM-1595 as it caused SMS loop at SMSC

--- a/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppService.java
+++ b/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppService.java
@@ -159,10 +159,12 @@ public final class SmppService extends RestcommUntypedActor {
             boolean countersEnabled = smppConfiguration.getBoolean("connections.connection(" + count + ").countersenabled");
 
             long enquireLinkDelay = smppConfiguration.getLong("connections.connection(" + count + ").enquirelinkdelay");
+            String inboundCharacterEncoding = smppConfiguration.getString("connections.connection(" + count + ").inboundencoding");
+            String outboundCharacterEncoding = smppConfiguration.getString("connections.connection(" + count + ").outboundencoding");
 
             Smpp smpp = new Smpp(name, systemId, peerIp, peerPort, bindtype, password, systemType, interfaceVersion, address,
                     connectTimeout, windowSize, windowWaitTimeout, requestExpiryTimeout, windowMonitorInterval,
-                    countersEnabled, logBytes, enquireLinkDelay);
+                    countersEnabled, logBytes, enquireLinkDelay, inboundCharacterEncoding, outboundCharacterEncoding);
 
             this.smppList.add(smpp);
 

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/smpp/SmppTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/smpp/SmppTest.java
@@ -46,6 +46,7 @@ import org.restcomm.connect.commons.annotations.SequentialClassTests;
 import org.restcomm.connect.commons.annotations.WithInSecsTests;
 import org.restcomm.connect.sms.smpp.SmppInboundMessageEntity;
 
+import com.cloudhopper.commons.charset.Charset;
 import com.cloudhopper.commons.charset.CharsetUtil;
 import com.cloudhopper.smpp.type.SmppChannelException;
 import com.cloudhopper.smpp.type.SmppInvalidArgumentException;
@@ -66,9 +67,9 @@ public class SmppTest {
     private static String to = "7777";
     private static String toPureSipProviderNumber = "7007";
     private static String from = "9999";
-    private static String msgBody = "Message from SMPP Server to Restcomm";
-    private static String msgBodyResp = "Response from Restcomm to SMPP server";
-    private static String msgBodyRespUCS2 = "Response from Restcomm to SMPP serverПППРРр";
+    private static String msgBody = "か~!@#$%^&*()-=\u263a\u00a1\u00a2\u00a3\u00a4\u00a5Message from SMPP Server to Restcomm";
+    private static String msgBodyResp = "か~!@#$%^&*()-=\u263a\u00a1\u00a2\u00a3\u00a4\u00a5Response from Restcomm to SMPP server";
+    private static String msgBodyRespUCS2 = "か~!@#$%^&*()-=\u263a\u00a1\u00a2\u00a3\u00a4\u00a5Response from Restcomm to SMPP server";
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(8090); // No-args constructor defaults to port 8080
@@ -190,27 +191,39 @@ public class SmppTest {
         Thread.sleep(2000);
 	}
 
-    private String smsEchoRcml = "<Response><Sms to=\""+from+"\" from=\""+to+"\">"+msgBodyResp+"</Sms></Response>";
-	@Test
-	public void testSendMessageToRestcomm () throws SmppInvalidArgumentException, IOException, InterruptedException {
+    @Test
+    public void testSendMessageToRestcommUTF8() throws SmppInvalidArgumentException, IOException, InterruptedException {
+        testSendMessageToRestcomm(msgBody, msgBodyResp, CharsetUtil.CHARSET_UTF_8);
+    }
 
-        stubFor(get(urlPathEqualTo("/smsApp"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "text/xml")
-                        .withBody(smsEchoRcml)));
+    @Test
+    public void testSendMessageToRestcommUCS2() throws SmppInvalidArgumentException, IOException, InterruptedException {
+        testSendMessageToRestcomm(msgBody, msgBodyRespUCS2, CharsetUtil.CHARSET_UCS_2);
+    }
 
-		mockSmppServer.sendSmppMessageToRestcomm(msgBody,to,from,CharsetUtil.CHARSET_GSM);
+    public void testSendMessageToRestcomm(String msgBodySend, String msgBodyResp, Charset charset) throws SmppInvalidArgumentException, IOException, InterruptedException {
+
+        String smsEchoRcml = "<Response><Sms to=\"" + from + "\" from=\"" + to + "\">" + msgBodyResp + "</Sms></Response>";
+        stubFor(get(urlPathEqualTo("/smsApp")).willReturn(aResponse()
+                .withStatus(200).withHeader("Content-Type", "text/xml")
+                .withBody(smsEchoRcml)));
+
+        mockSmppServer.sendSmppMessageToRestcomm(msgBodySend, to, from,
+                charset);
         Thread.sleep(2000);
         assertTrue(mockSmppServer.isMessageSent());
-		Thread.sleep(2000);
-		assertTrue(mockSmppServer.isMessageReceived());
-		SmppInboundMessageEntity inboundMessageEntity = mockSmppServer.getSmppInboundMessageEntity();
-		assertNotNull(inboundMessageEntity);
-		assertTrue(inboundMessageEntity.getSmppTo().equals(from));
-		assertTrue(inboundMessageEntity.getSmppFrom().equals(to));
-		assertTrue(inboundMessageEntity.getSmppContent().equals(msgBodyResp));
-	}
+        Thread.sleep(2000);
+        assertTrue(mockSmppServer.isMessageReceived());
+        SmppInboundMessageEntity inboundMessageEntity = mockSmppServer.getSmppInboundMessageEntity();
+        assertNotNull(inboundMessageEntity);
+
+        logger.info("msgBodyResp: " + msgBodyResp);
+        logger.info("getSmppContent: " + inboundMessageEntity.getSmppContent());
+
+        assertTrue(inboundMessageEntity.getSmppTo().equals(from));
+        assertTrue(inboundMessageEntity.getSmppFrom().equals(to));
+        assertTrue(inboundMessageEntity.getSmppContent().equals(msgBodyResp));
+    }
 
     private String smsEchoRcmlPureSipProviderNumber = "<Response><Sms to=\""+from+"\" from=\""+toPureSipProviderNumber+"\">"+msgBodyResp+"</Sms></Response>";
 	@Test //https://telestax.atlassian.net/browse/RESTCOMM-1428, https://telestax.atlassian.net/browse/POSTMORTEM-13
@@ -237,7 +250,7 @@ public class SmppTest {
     private String smsEchoRcmlUCS2 = "<Response><Sms to=\""+from+"\" from=\""+to+"\">"+msgBodyRespUCS2+"</Sms></Response>";
 	@Test
     @Category(value={FeatureAltTests.class, BrokenTests.class})
-	public void testSendMessageToRestcommUCS2 () throws SmppInvalidArgumentException, IOException, InterruptedException {
+	public void testSendMessageToRestcommUCS2_2 () throws SmppInvalidArgumentException, IOException, InterruptedException {
 
         stubFor(get(urlPathEqualTo("/smsApp"))
                 .willReturn(aResponse()

--- a/restcomm/restcomm.testsuite/src/test/resources/restcomm-smpp.xml
+++ b/restcomm/restcomm.testsuite/src/test/resources/restcomm-smpp.xml
@@ -297,6 +297,9 @@
 					If no response received for 3 consecutive requests, connection will be killed
 					and attempted to connect again -->
 				<enquirelinkdelay>30000</enquirelinkdelay>
+				<!-- when no values are set, default value from code is MODIFIED-UTF8 inbound, GSM7 for outbound-->
+				<inboundencoding>UTF-8</inboundencoding>
+				<outboundencoding>UTF-8</outboundencoding>
 			</connection>
 		</connections>
 	</smpp>


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow multiprovider extension to define encoding for incoming and outgoing sms

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #RESTCOMM-1856

**Special notes for your reviewer**:
