### PR TITLE
SIP REFER method is now working with organizations

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/SIPOrganizationUtil.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/SIPOrganizationUtil.java
@@ -42,13 +42,33 @@ public class SIPOrganizationUtil {
         return organization == null ? null : organization.getSid();
     }
 
-    public static Sid searchOrganizationBySIPRequest(OrganizationsDao orgDao, SipServletRequest request) {
-        //first try with requetURI
-        Sid destinationOrganizationSid = getOrganizationSidBySipURIHost(orgDao,
-                (SipURI) request.getRequestURI());
-        if (destinationOrganizationSid == null) {
+    public static Sid searchOrganizationBySIPRequest(OrganizationsDao orgDao, SipServletRequest request)
+    {
+        Sid destinationOrganizationSid = null;
+        SipURI sipURI = null;
+        if (!request.getMethod().equals("REFER")) {
+            //first try with requetURI
+            destinationOrganizationSid = getOrganizationSidBySipURIHost(orgDao, (SipURI)request.getRequestURI());
             // try to get destinationOrganizationSid from toUri
-            destinationOrganizationSid = getOrganizationSidBySipURIHost(orgDao, (SipURI) request.getTo().getURI());
+            if (destinationOrganizationSid == null) {
+                destinationOrganizationSid = getOrganizationSidBySipURIHost(orgDao, (SipURI)request.getTo().getURI());
+            }
+        }else{
+            // The Request URI from SIP REFER method is going with the IP Address instead of the domain name
+            // try to get destinationOrganizationSid from Refer-To
+            try{
+                sipURI = (SipURI)request.getAddressHeader("Refer-To").getURI();
+            } catch (ServletParseException e){
+                logger.error("sipURI is NULL");
+            }
+            if (sipURI != null){
+                destinationOrganizationSid = getOrganizationSidBySipURIHost(orgDao, sipURI);
+                if(destinationOrganizationSid == null){
+                    logger.error("destinationOrganizationSid is NULL: Refer-To Uri is: "+ sipURI);
+                }else{
+                    logger.debug("searchOrganizationBySIPRequest: destinationOrganizationSid: "+destinationOrganizationSid +" Refer-To Uri is: "+sipURI);
+                }
+            }
         }
         return destinationOrganizationSid;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
When Restcomm Connect (RC) receives a REFER request and RC is configured with a domain name as hostname, the Sip-URI in Request-URI header is always coming with the RC IP address. So, we have to use the Refer-To header to get Sip-URI that contains the domain name, then it can get the destination Organization SID properly.

**Which issue(s) this PR fixes** Fixes #2902

**Special notes for your reviewer**:
The SipURI is taken from Refer-To header. The searchOrganizationBySIPRequest method is used by SIP methods: INVITE and REFER in CallManager class, so I validate into the method if the request is REFER.