### PR TITLE
#2895 Stop ringing tone before move to next verb when Dial verb fail …

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
@@ -1328,6 +1328,12 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                     if (dialBranches != null && dialBranches.contains(sender)) {
                         dialBranches.remove(sender);
                     }
+                    if (dialBranches == null || dialBranches.size() == 0){
+                        // https://github.com/RestComm/Restcomm-Connect/issues/2895
+                        // Race condition If there is Play/Say Verb after dial verb, if the Dia verb is failing to call to the other,
+                        // NTFY to stop ringing tone also stop RQNT for playing/say verb. Better to stop it here.
+                        call.tell(new StopMediaGroup(), self());
+                    }
                     checkDialBranch(message,sender,action);
                 } else if (sender.equals(call)) {
                     fsm.transition(message, finished);


### PR DESCRIPTION
In Dial Action verb, there is Play/Say verb. If callee in Dial Verb return back 480 Unavailable. RC send RQNT for stop ringing tone and RQNT for play verb really fast at the same time. When Media server return back NTFY for stoping ringing tone RQNT, RC understand this is NTFY for Playing verb that make RC move to next verb and finish Play/Say verb at this point