### PR TITLE
RESTCOMM-2064: Refactor ExtensionController and implement getEffectiveConfiguration

### DIFF
--- a/restcomm/restcomm.extension.api/src/main/java/org/restcomm/connect/extension/api/ExtensionContext.java
+++ b/restcomm/restcomm.extension.api/src/main/java/org/restcomm/connect/extension/api/ExtensionContext.java
@@ -1,0 +1,25 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2013, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.restcomm.connect.extension.api;
+
+public interface ExtensionContext {
+    ExtensionConfiguration getEffectiveConfiguration(String extensionSid, String scopeSid);
+}

--- a/restcomm/restcomm.extension.controller/src/main/java/org/restcomm/connect/extension/controller/ExtensionBootstrapper.java
+++ b/restcomm/restcomm.extension.controller/src/main/java/org/restcomm/connect/extension/controller/ExtensionBootstrapper.java
@@ -20,6 +20,7 @@
  */
 package org.restcomm.connect.extension.controller;
 
+import org.restcomm.connect.extension.api.ExtensionContext;
 import org.restcomm.connect.extension.api.RestcommExtensionGeneric;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.HierarchicalConfiguration;
@@ -43,6 +44,8 @@ public class ExtensionBootstrapper {
     public ExtensionBootstrapper(final ServletContext context, final Configuration configuration) {
         this.configuration = configuration;
         this.context = context;
+        this.context.setAttribute(ExtensionContext.class.getName(), ExtensionController.getInstance());
+        ExtensionController.getInstance().init(this.context);
     }
 
     public void start() throws ClassNotFoundException, IllegalAccessException, InstantiationException {


### PR DESCRIPTION
**What this PR does / why we need it**:
Centralize configuration hierarchy lookup in `getEffectiveConfiguration`. Add an `ExtensionContext` interface for implementing extensions to access public extension framework functionality.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # RESTCOMM-2064, RESTCOMM-1617

**Special notes for your reviewer**:
Decided to go with `ExtensionContext` instead of `ExtensionControllerFacade`.
One other possible option is to not have `ExtensionController` implement `ExtensionContext` but create  new `ExtensionContextImpl` class instead