### PR TITLE
Allow specifying content type in Email endpoint

### DIFF
--- a/restcomm/restcomm.docs/sources-asciidoc/src/main/asciidoc/api/email-api.adoc
+++ b/restcomm/restcomm.docs/sources-asciidoc/src/main/asciidoc/api/email-api.adoc
@@ -33,6 +33,7 @@ Using the RestComm API, you can send Emails through a simple request.
 |To(Required) |The destination Email address.
 |Body(Required) |The body of the Email message.
 |Subject(Required) |The subject of the Email message.(Max. 160 chars.)
+|Type |The value to be used in the Content-Type header of the email message. (eg text/html for HTML emails)
 |BCC |The Blind Carbon Copy feature (Bcc).  (Hide addresses when sending an Email to various recipients)
 |CC |The Carbon Copy (Cc). (The list of CCed recipients is visible to all other recipients of the message.)
 |==========================================================================================================

--- a/restcomm/restcomm.email.api/src/main/java/org/restcomm/connect/email/api/Mail.java
+++ b/restcomm/restcomm.email.api/src/main/java/org/restcomm/connect/email/api/Mail.java
@@ -35,33 +35,21 @@ public final class Mail {
     private final String body;
     private final DateTime dateSent;
     private final String accountSid;
+    private final String contentType;
 
     public Mail(final String from, final String to, final String subject, final String body) {
-        super();
-        this.from = from;
-        this.to = to;
-        this.cc = "";
-        this.bcc = "";
-        this.subject = subject;
-        this.body = body;
-        this.dateSent = DateTime.now();
-        this.accountSid = "";
+        this(from, to, subject, body, "", "", DateTime.now(), "", "text/plain");
     }
 
-    public Mail(final String from, final String to, final String subject, final String body,final String cc,final String bcc) {
-        super();
-        this.from = from;
-        this.to = to;
-        this.cc = cc;
-        this.bcc = bcc;
-        this.subject = subject;
-        this.body = body;
-        this.dateSent = DateTime.now();
-        this.accountSid = "";
+    public Mail(final String from, final String to, final String subject, final String body, final String cc, final String bcc) {
+        this(from, to, subject, body, cc, bcc, DateTime.now(), "", "text/plain");
     }
 
-    public Mail(final String from, final String to, final String subject, final String body,final String cc,final String bcc, final DateTime dateSent ,final String accountSid) {
-        super();
+    public Mail(final String from, final String to, final String subject, final String body, final String cc, final String bcc, final DateTime dateSent, final String accountSid) {
+        this(from, to, subject, body, cc, bcc, dateSent, accountSid, "text/plain");
+    }
+
+    public Mail(final String from, final String to, final String subject, final String body, final String cc, final String bcc, final DateTime dateSent, final String accountSid, final String contentType) {
         this.from = from;
         this.to = to;
         this.cc = cc;
@@ -70,6 +58,7 @@ public final class Mail {
         this.body = body;
         this.dateSent = dateSent;
         this.accountSid = accountSid;
+        this.contentType = contentType;
     }
 
     public String from() {
@@ -94,6 +83,10 @@ public final class Mail {
 
     public String body() {
         return body;
+    }
+
+    public String contentType() {
+        return contentType;
     }
 
     public String accountSid() {

--- a/restcomm/restcomm.email/src/main/java/org/restcomm/connect/email/EmailService.java
+++ b/restcomm/restcomm.email/src/main/java/org/restcomm/connect/email/EmailService.java
@@ -159,7 +159,7 @@ public class EmailService extends RestcommUntypedActor {
             email.setFrom(from);
             email.addRecipient(Message.RecipientType.TO, to);
             email.setSubject(mail.subject());
-            email.setText(mail.body());
+            email.setContent(mail.body(), mail.contentType());
             email.addRecipients(Message.RecipientType.CC, InternetAddress.parse(mail.cc(), false));
             email.addRecipients(Message.RecipientType.BCC,InternetAddress.parse(mail.bcc(),false));
             //Transport.send(email);
@@ -185,7 +185,7 @@ public class EmailService extends RestcommUntypedActor {
             email.setFrom(from);
             email.addRecipient(Message.RecipientType.TO, to);
             email.setSubject(mail.subject());
-            email.setText(mail.body());
+            email.setContent(mail.body(), mail.contentType());
             email.addRecipients(Message.RecipientType.CC, InternetAddress.parse(mail.cc(), false));
             email.addRecipients(Message.RecipientType.BCC,InternetAddress.parse(mail.bcc(),false));
             Transport.send(email);


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for specifying content-type sending emails through Email endpoint

