### PR TITLE
allow proxy-authorization header to omit algortihm param

### DIFF
--- a/restcomm/pom.xml
+++ b/restcomm/pom.xml
@@ -535,6 +535,20 @@
             </dependency>
             <!-- Testing -->
             <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>1.6.2</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>1.6.2</version>
+                <scope>test</scope>
+            </dependency>
+            
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>

--- a/restcomm/pom.xml
+++ b/restcomm/pom.xml
@@ -534,20 +534,7 @@
                 <version>${libphonenumber.version}</version>
             </dependency>
             <!-- Testing -->
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito</artifactId>
-                <version>1.6.2</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>1.6.2</version>
-                <scope>test</scope>
-            </dependency>
-            
+           
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>

--- a/restcomm/restcomm.commons/src/main/java/org/restcomm/connect/commons/util/DigestAuthentication.java
+++ b/restcomm/restcomm.commons/src/main/java/org/restcomm/connect/commons/util/DigestAuthentication.java
@@ -127,8 +127,6 @@ public final class DigestAuthentication {
             throw new NullPointerException("The uri parameter may not be null.");
         } else if (nonce == null) {
             throw new NullPointerException("The nonce parameter may not be null.");
-        } else if (algorithm == null) {
-            throw new NullPointerException("The algorithm parameter may not be null.");
         }
     }
 

--- a/restcomm/restcomm.telephony.api/pom.xml
+++ b/restcomm/restcomm.telephony.api/pom.xml
@@ -1,65 +1,77 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.restcomm</groupId>
-		<artifactId>restcomm-connect</artifactId>
-		<version>9.0.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>restcomm-connect.telephony.api</artifactId>
-	<name>restcomm-connect.telephony.api</name>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.restcomm</groupId>
+        <artifactId>restcomm-connect</artifactId>
+        <version>9.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>restcomm-connect.telephony.api</artifactId>
+    <name>restcomm-connect.telephony.api</name>
 
-	<dependencies>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<scope>provided</scope>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.mobicents.servlet.sip</groupId>
-			<artifactId>sip-servlets-spec</artifactId>
-			<version>${sipservletapi.version}</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.mobicents.servlet.sip</groupId>
+            <artifactId>sip-servlets-spec</artifactId>
+            <version>${sipservletapi.version}</version>
+            <scope>provided</scope>
+        </dependency>
                 
                                
-		<dependency>
-			<groupId>org.mobicents.servlet.sip.containers</groupId>
-			<artifactId>sip-servlets-catalina-7</artifactId>
-			<scope>provided</scope>
-		</dependency>                 
+        <dependency>
+            <groupId>org.mobicents.servlet.sip.containers</groupId>
+            <artifactId>sip-servlets-catalina-7</artifactId>
+            <scope>provided</scope>
+        </dependency>                 
 
-		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>org.restcomm</groupId>
-			<artifactId>restcomm-connect.commons</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.restcomm</groupId>
+            <artifactId>restcomm-connect.commons</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.restcomm</groupId>
             <artifactId>restcomm-connect.extension.api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-		<dependency>
-			<groupId>org.restcomm</groupId>
-			<artifactId>restcomm-connect.dao</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>org.restcomm</groupId>
+            <artifactId>restcomm-connect.dao</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-		<dependency>
-			<groupId>javax.sip</groupId>
-			<artifactId>jain-sip-ri</artifactId>
-			<scope>provided</scope>
-		</dependency>
+        <dependency>
+            <groupId>javax.sip</groupId>
+            <artifactId>jain-sip-ri</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-	</dependencies>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
 </project>

--- a/restcomm/restcomm.telephony.api/pom.xml
+++ b/restcomm/restcomm.telephony.api/pom.xml
@@ -61,17 +61,5 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/restcomm/restcomm.telephony.api/src/main/java/org/restcomm/connect/telephony/api/util/CallControlHelper.java
+++ b/restcomm/restcomm.telephony.api/src/main/java/org/restcomm/connect/telephony/api/util/CallControlHelper.java
@@ -54,7 +54,7 @@ public class CallControlHelper {
     public static boolean permitted(final String authorization, final String method, DaoManager daoManager, final Sid organizationSid) {
         final Map<String, String> map = authHeaderToMap(authorization);
         final String user = map.get("username");
-        final String authHeaderAlgorithm = map.get("algorithm");
+        String authHeaderAlgorithm = map.get("algorithm");
         final String realm = map.get("realm");
         final String uri = map.get("uri");
         final String nonce = map.get("nonce");
@@ -72,6 +72,9 @@ public class CallControlHelper {
         if (client != null && Client.ENABLED == client.getStatus()) {
             final String password = client.getPassword();
             final String clientPasswordAlgorithm = client.getPasswordAlgorithm();
+            if (authHeaderAlgorithm == null) {
+                authHeaderAlgorithm = clientPasswordAlgorithm;
+            }
             final String result = DigestAuthentication.response(authHeaderAlgorithm, user, realm, password,clientPasswordAlgorithm, nonce, nc, cnonce,
                     method, uri, null, qop);
             if (logger.isDebugEnabled()) {

--- a/restcomm/restcomm.telephony.api/src/test/java/org/restcomm/connect/telephony/api/util/CallControlHelperTest.java
+++ b/restcomm/restcomm.telephony.api/src/test/java/org/restcomm/connect/telephony/api/util/CallControlHelperTest.java
@@ -19,28 +19,17 @@
  */
 package org.restcomm.connect.telephony.api.util;
 
-import gov.nist.javax.sip.clientauthutils.AccountManager;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.junit.runner.RunWith;
-import static org.mockito.Matchers.any;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.restcomm.connect.commons.configuration.RestcommConfiguration;
-import org.restcomm.connect.commons.configuration.sets.MainConfigurationSet;
 import org.restcomm.connect.commons.dao.Sid;
-import org.restcomm.connect.commons.util.DigestAuthentication;
 import org.restcomm.connect.dao.AccountsDao;
 import org.restcomm.connect.dao.ClientsDao;
 import org.restcomm.connect.dao.DaoManager;
 import org.restcomm.connect.dao.entities.Account;
 import org.restcomm.connect.dao.entities.Client;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CallControlHelper.class)
 public class CallControlHelperTest {
 
     public CallControlHelperTest() {

--- a/restcomm/restcomm.telephony.api/src/test/java/org/restcomm/connect/telephony/api/util/CallControlHelperTest.java
+++ b/restcomm/restcomm.telephony.api/src/test/java/org/restcomm/connect/telephony/api/util/CallControlHelperTest.java
@@ -1,0 +1,111 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2014, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+package org.restcomm.connect.telephony.api.util;
+
+import gov.nist.javax.sip.clientauthutils.AccountManager;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.runner.RunWith;
+import static org.mockito.Matchers.any;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.restcomm.connect.commons.configuration.RestcommConfiguration;
+import org.restcomm.connect.commons.configuration.sets.MainConfigurationSet;
+import org.restcomm.connect.commons.dao.Sid;
+import org.restcomm.connect.commons.util.DigestAuthentication;
+import org.restcomm.connect.dao.AccountsDao;
+import org.restcomm.connect.dao.ClientsDao;
+import org.restcomm.connect.dao.DaoManager;
+import org.restcomm.connect.dao.entities.Account;
+import org.restcomm.connect.dao.entities.Client;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(CallControlHelper.class)
+public class CallControlHelperTest {
+
+    public CallControlHelperTest() {
+    }
+
+    @Test
+    public void testPermitted() {
+        String auth = "Digest username=\"alice\",realm=\"127.0.0.1\",nonce=\"64353235316666342d306434392d343\",uri=\"sip:127.0.0.1:5080\",response=\"31927ed6bc4b0c3796fd2240f8315fc7\",cnonce=\"416ba85980000000\",nc=00000001,qop=auth,algorithm=MD5";
+        String method = "REGISTER";
+        Sid organization = Sid.generate(Sid.Type.ORGANIZATION);
+        Sid accountSid = Sid.generate(Sid.Type.ACCOUNT);
+        Account.Builder builder = Account.builder();
+        builder.setSid(accountSid);
+        builder.setStatus(Account.Status.ACTIVE);
+        Account account = builder.build();
+        Client.Builder builder2 = Client.builder();
+        builder2.setSid(Sid.generate(Sid.Type.CLIENT));
+        builder2.setAccountSid(accountSid);
+        //use no algorithm to skip conf mocking
+        builder2.setPassword("alice", "2ea216cdda59f04ef9ba21fead1bca10", "127.0.0.1", "");
+        builder2.setPasswordAlgorithm("MD5");
+        builder2.setStatus(Client.ENABLED);
+        Client client = builder2.build();
+
+        DaoManager manager = Mockito.mock(DaoManager.class);
+        ClientsDao clients = Mockito.mock(ClientsDao.class);
+        AccountsDao accounts = Mockito.mock(AccountsDao.class);
+        when(manager.getClientsDao()).thenReturn(clients);
+        when(clients.getClient("alice", organization)).thenReturn(client);
+        when(manager.getAccountsDao()).thenReturn(accounts);
+        when(accounts.getAccount(accountSid)).thenReturn(account);
+
+        boolean permitted = CallControlHelper.permitted(auth, method, manager, organization);
+        assertTrue(permitted);
+    }
+
+    @Test
+    public void testPermittedNoAlgorithm() {
+        String auth = "Digest username=\"alice\",realm=\"127.0.0.1\",nonce=\"64353235316666342d306434392d343\",uri=\"sip:127.0.0.1:5080\",response=\"31927ed6bc4b0c3796fd2240f8315fc7\",cnonce=\"416ba85980000000\",nc=00000001,qop=auth";
+        String method = "REGISTER";
+        Sid organization = Sid.generate(Sid.Type.ORGANIZATION);
+        Sid accountSid = Sid.generate(Sid.Type.ACCOUNT);
+        Account.Builder builder = Account.builder();
+        builder.setSid(accountSid);
+        builder.setStatus(Account.Status.ACTIVE);
+        Account account = builder.build();
+        Client.Builder builder2 = Client.builder();
+        builder2.setSid(Sid.generate(Sid.Type.CLIENT));
+        builder2.setAccountSid(accountSid);
+        //use no algorithm to skip conf mocking
+        builder2.setPassword("alice", "2ea216cdda59f04ef9ba21fead1bca10", "127.0.0.1", "");
+        builder2.setPasswordAlgorithm("MD5");
+        builder2.setStatus(Client.ENABLED);
+        Client client = builder2.build();
+
+        DaoManager manager = Mockito.mock(DaoManager.class);
+        ClientsDao clients = Mockito.mock(ClientsDao.class);
+        AccountsDao accounts = Mockito.mock(AccountsDao.class);
+        when(manager.getClientsDao()).thenReturn(clients);
+        when(clients.getClient("alice", organization)).thenReturn(client);
+        when(manager.getAccountsDao()).thenReturn(accounts);
+        when(accounts.getAccount(accountSid)).thenReturn(account);
+
+        boolean permitted = CallControlHelper.permitted(auth, method, manager, organization);
+        assertTrue(permitted);
+    }
+
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
allow proxy-authorization header to omit algortihm param. Allow clients not setting this param to work with Restcomm (linphone)
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://telestax.atlassian.net/browse/BS-112

**Special notes for your reviewer**:
