### PR TITLE
jira_2087 Say/Play verb can be executed in failed Dial verb.

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
@@ -233,6 +233,7 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
 
     // Controls if VI will wait MS response to move to the next verb
     protected boolean msResponsePending;
+    private boolean msStopingRingTone = false;
 
     private boolean callWaitingForAnswer = false;
 
@@ -833,7 +834,12 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
             if (is(playingRejectionPrompt)) {
                 fsm.transition(message, hangingUp);
             } else if (is(playing)) {
-                fsm.transition(message, ready);
+                logger.info ("Is restcomm stoping ring tone: " + msStopingRingTone);
+                // When RestComm is requesting stop ring tone, the first NTFY response is for stop ring tone,
+                // instead for play/say verb. When enable200OkDelay = true, there is no NTFY for stop ring tone.
+                if (!msStopingRingTone || enable200OkDelay) {
+                    fsm.transition(message, ready);
+                }
             } else if (is(creatingRecording)) {
                 if (logger.isInfoEnabled()) {
                     logger.info("Will move to finishRecording because of MediaGroupResponse");
@@ -898,6 +904,10 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                     final GetNextVerb next = new GetNextVerb();
                     parser.tell(next, self());
                 }
+            }
+
+            if (msStopingRingTone) {
+                msStopingRingTone = !(((MediaGroupResponse) message).get() instanceof CollectedResult);
             }
         } else {
             fsm.transition(message, hangingUp);
@@ -1286,8 +1296,7 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                         }
                         if (dialBranches == null || dialBranches.size() == 0){
                             // Stop playing the ringing tone from inbound call
-                            msResponsePending = true;
-                            call.tell(new StopMediaGroup(), self());
+                            stopRingTone();
                         }
                         checkDialBranch(message, sender, action);
                         return;
@@ -1327,6 +1336,10 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                 if (!sender.equals(call)) {
                     if (dialBranches != null && dialBranches.contains(sender)) {
                         dialBranches.remove(sender);
+                    }
+                    if (dialBranches == null || dialBranches.size() == 0){
+                        // Stop playing the ringing tone from inbound call
+                        stopRingTone();
                     }
                     checkDialBranch(message,sender,action);
                 } else if (sender.equals(call)) {
@@ -1393,7 +1406,13 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                 if(call!=null && (call == sender) && event.state().equals(CallStateChanged.State.WAIT_FOR_ANSWER)){
                     callWaitingForAnswer  = true;
                 }
-                if (is(initializingCall) || is(rejecting)) {
+                if (enable200OkDelay && sender.equals(call) && event.state().equals(CallStateChanged.State.IN_PROGRESS) && callWaitingForAnswerPendingTag != null) {
+                    if (logger.isInfoEnabled()) {
+                        logger.info("Waiting call is inProgress we can proceed to the pending tag execution");
+                    }
+                    callWaitingForAnswer = false;
+                    onTagMessage(callWaitingForAnswerPendingTag);
+                } else if (is(initializingCall) || is(rejecting)) {
                     if (parser != null) {
                         //This is an inbound call
                         fsm.transition(message, ready);
@@ -1422,13 +1441,8 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                         final GetNextVerb next = new GetNextVerb();
                         parser.tell(next, self());
                     }
-                } else if (enable200OkDelay && sender.equals(call) && event.state().equals(CallStateChanged.State.IN_PROGRESS) && callWaitingForAnswerPendingTag != null) {
-                    if (logger.isInfoEnabled()) {
-                        logger.info("Waiting call is inProgress we can proceed to the pending tag execution");
-                    }
-                    callWaitingForAnswer = false;
-                    onTagMessage(callWaitingForAnswerPendingTag);
                 }
+
                 // Update the storage for conferencing.
                 if (callRecord != null && !is(initializingCall) && !is(rejecting)) {
                     final CallDetailRecordsDao records = storage.getCallDetailRecordsDao();
@@ -1712,6 +1726,13 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                 }
             }
         }
+    }
+
+    private void stopRingTone() {
+        // Stop playing the ringing tone from inbound call
+        msResponsePending = true;
+        msStopingRingTone = true;
+        call.tell(new StopMediaGroup(), self());
     }
 
     private abstract class AbstractAction implements Action {
@@ -2842,8 +2863,7 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                         }
                     }
                     // Stop playing the ringing tone from inbound call
-                    msResponsePending = true;
-                    call.tell(new StopMediaGroup(), self());
+                    stopRingTone();
                 } else if (outboundCall != null) {
                     outboundCall.tell(new Cancel(), source);
                     call.tell(new Hangup(outboundCallResponse), self());

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGateway.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockMediaGateway.java
@@ -653,8 +653,10 @@ public class MockMediaGateway extends RestcommUntypedActor {
         final NotificationRequest request = (NotificationRequest) message;
 
         MgcpEvent event = null;
-        if (request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("es")
-                || request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("pr")) {
+        // Remove case RQNT for stoping media instead of stop recording.
+        if (!request.getSignalRequests()[0].getEventIdentifier().getParms().equalsIgnoreCase("sg=pa") &&
+                (request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("es") ||
+                        request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("pr"))) {
             //Looks like this is either an RQNT AU/ES or
             //recording max length reached and we got the original recording RQNT
             event = AUMgcpEvent.auoc.withParm("AU/pr ri=file://" + recordingFile.toPath() + " rc=100 dc=1");
@@ -700,7 +702,9 @@ public class MockMediaGateway extends RestcommUntypedActor {
             }
         }
 
-        if (events != null && !events[0].getEventIdentifier().getName().equalsIgnoreCase("pr")) {
+        if (events != null && !events[0].getEventIdentifier().getName().equalsIgnoreCase("pr") &&
+                // In real scenario, there is no NTFY for finish ringing immediately.
+                !events[0].getEventIdentifier().getParms().contains("ringing.wav")) {
             if (NotificationRequest.class.equals(command.getClass())) {
                 final NotificationRequest request = (NotificationRequest) command;
                 final String id = Long.toString(requestIdPool.get());

--- a/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockPlayDelayMediaGateway.java
+++ b/restcomm/restcomm.mgcp/src/main/java/org/restcomm/connect/mgcp/MockPlayDelayMediaGateway.java
@@ -38,8 +38,9 @@ public class MockPlayDelayMediaGateway extends MockMediaGateway {
         final NotificationRequest request = (NotificationRequest) message;
 
         MgcpEvent event = null;
-        if (request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("es")
-                || request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("pr")) {
+        if (!request.getSignalRequests()[0].getEventIdentifier().getParms().equalsIgnoreCase("sg=pa") &&
+                (request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("es") ||
+                        request.getSignalRequests()[0].getEventIdentifier().getName().equalsIgnoreCase("pr"))) {
             //Looks like this is either an RQNT AU/ES or
             //recording max length reached and we got the original recording RQNT
             event = AUMgcpEvent.auoc.withParm("AU/pr ri=file://" + recordingFile.toPath() + " rc=100 dc=1");


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
Say/Play Verb after Dial Verb, If callee is busy (486 BUSY) or in another call (480 Unavailable), RC will stop Say/Play verb really fast.

RC stop ringing tone then asking for next verb without waiting for mgcp NTFY. If next verb is say/play that makes RC moves to playing state before mgcp NTFY for stoping ringtone actually come to RC. When mgcp NTFY for stoping ringtone come, RC is in playing stay will stop say/play verb

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://telestax.atlassian.net/browse/RESTCOMM-2087
**Special notes for your reviewer**:
There is 2 big customer is waiting for this fix.