### PR TITLE
Avoid duplicate correlations to same SMPP Message ID

### DIFF
--- a/restcomm/restcomm.dao/src/main/java/org/restcomm/connect/dao/entities/SmsMessage.java
+++ b/restcomm/restcomm.dao/src/main/java/org/restcomm/connect/dao/entities/SmsMessage.java
@@ -187,64 +187,79 @@ public class SmsMessage implements StreamEvent {
                     priceUnit, apiVersion, uri, smppMessageId);
         }
 
-        public void setSid(final Sid sid) {
+        public Builder setSid(final Sid sid) {
             this.sid = sid;
+            return this;
         }
 
-        public void setDateSent(final DateTime dateSent) {
+        public Builder setDateSent(final DateTime dateSent) {
             this.dateSent = dateSent;
+            return this;
         }
 
-        public void setAccountSid(final Sid accountSid) {
+        public Builder setAccountSid(final Sid accountSid) {
             this.accountSid = accountSid;
+            return this;
         }
 
-        public void setSender(final String sender) {
+        public Builder setSender(final String sender) {
             this.sender = sender;
+            return this;
         }
 
-        public void setRecipient(final String recipient) {
+        public Builder setRecipient(final String recipient) {
             this.recipient = recipient;
+            return this;
         }
 
-        public void setBody(final String body) {
+        public Builder setBody(final String body) {
             this.body = body;
+            return this;
         }
 
-        public void setStatus(final Status status) {
+        public Builder setStatus(final Status status) {
             this.status = status;
+            return this;
         }
 
-        public void setDirection(final Direction direction) {
+        public Builder setDirection(final Direction direction) {
             this.direction = direction;
+            return this;
         }
 
-        public void setPrice(final BigDecimal price) {
+        public Builder setPrice(final BigDecimal price) {
             this.price = price;
+            return this;
         }
 
-        public void setPriceUnit(Currency priceUnit) {
+        public Builder setPriceUnit(Currency priceUnit) {
             this.priceUnit = priceUnit;
+            return this;
         }
 
-        public void setApiVersion(final String apiVersion) {
+        public Builder setApiVersion(final String apiVersion) {
             this.apiVersion = apiVersion;
+            return this;
         }
 
-        public void setUri(final URI uri) {
+        public Builder setUri(final URI uri) {
             this.uri = uri;
+            return this;
         }
 
-        public void setDateCreated(DateTime dateCreated) {
+        public Builder setDateCreated(DateTime dateCreated) {
             this.dateCreated = dateCreated;
+            return this;
         }
 
-        public void setDateUpdated(DateTime dateUpdated) {
+        public Builder setDateUpdated(DateTime dateUpdated) {
             this.dateUpdated = dateUpdated;
+            return this;
         }
 
-        public void setSmppMessageId(String smppMessageId) {
+        public Builder setSmppMessageId(String smppMessageId) {
             this.smppMessageId = smppMessageId;
+            return this;
         }
     }
 

--- a/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppMessageHandler.java
+++ b/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppMessageHandler.java
@@ -190,8 +190,8 @@ public class SmppMessageHandler extends RestcommUntypedActor {
                     SmsMessage existingMessage = this.storage.getSmsMessagesDao().getSmsMessageBySmppMessageId(smppMessageId);
                     if (existingMessage != null) {
                         // Cut correlation between SMS and SMPP Message ID and update message to a final state
-                        existingMessage = existingMessage.setSmppMessageId(null).setStatus(SmsMessage.Status.FAILED);
-                        logger.warning("SmsMessage " + existingMessage.getSid() + " failed. Reason: Correlation with SMPP Message " + smppMessageId + " expired.");
+                        existingMessage = existingMessage.setSmppMessageId(null);
+                        logger.warning("Correlation between SmsMessage " + existingMessage.getSid() + " and SMPP Message " + smppMessageId + " expired.");
                         this.storage.getSmsMessagesDao().updateSmsMessage(existingMessage);
                     }
 

--- a/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppMessageHandler.java
+++ b/restcomm/restcomm.sms/src/main/java/org/restcomm/connect/sms/smpp/SmppMessageHandler.java
@@ -151,8 +151,7 @@ public class SmppMessageHandler extends RestcommUntypedActor {
                 logger.warning("responseMessageId=" + dLRPayload.getId() + " was never received! ");
             } else {
                 // Clean correlation to SMPP Message ID because SMPP identifiers are may repeat after a given time frame
-                smsMessage.setSmppMessageId(null);
-                smsMessagesDao.updateSmsMessage(smsMessage.setStatus(dLRPayload.getStat()));
+                smsMessagesDao.updateSmsMessage(smsMessage.setSmppMessageId(null).setStatus(dLRPayload.getStat()));
             }
         } else if (message instanceof CreateSmsSession) {
             IExtensionCreateSmsSessionRequest ier = (CreateSmsSession) message;

--- a/restcomm/restcomm.sms/src/test/java/org/restcomm/connect/sms/smpp/SmppMessageHandlerTest.java
+++ b/restcomm/restcomm.sms/src/test/java/org/restcomm/connect/sms/smpp/SmppMessageHandlerTest.java
@@ -257,7 +257,7 @@ public class SmppMessageHandlerTest {
                 final List<SmsMessage> capturedSms = smsCaptor.getAllValues();
                 assertEquals(2, capturedSms.size());
                 assertNull(capturedSms.get(0).getSmppMessageId());
-                assertEquals(SmsMessage.Status.FAILED, capturedSms.get(0).getStatus());
+                assertEquals(SmsMessage.Status.QUEUED, capturedSms.get(0).getStatus());
                 assertEquals(smppMessageId, capturedSms.get(1).getSmppMessageId());
                 assertEquals(SmsMessage.Status.SENT, capturedSms.get(1).getStatus());
             }


### PR DESCRIPTION
**What this PR does / why we need it**:

Safety net mechanism to make sure that no two SMS messages share same SMPP Message ID.
Happens in remote chance that an SMS never received a DLR in timely fashion.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes BS-230

**Special notes for your reviewer**:

Also include a minor patch for BS-229 where status of SMS message was not being persisted to DB.
