### PR TITLE
Create database index for SMPP Message ID

### DIFF
--- a/restcomm/restcomm.application/src/main/webapp/WEB-INF/scripts/mariadb/init.sql
+++ b/restcomm/restcomm.application/src/main/webapp/WEB-INF/scripts/mariadb/init.sql
@@ -466,6 +466,9 @@ CREATE INDEX idx_cdr_conference_sid ON restcomm_call_detail_records (conference_
 /* Create index on restcomm_call_detail_records on conference_sid column */
 CREATE INDEX idx_cdr_conference_status ON restcomm_conference_detail_records (status);
 
+/* Create index on restcomm_sms_messages on smpp_message_id column */
+CREATE INDEX idx_restcomm_sms_messages_smpp_message_id ON restcomm_sms_messages (smpp_message_id);
+
 DELIMITER //
 DROP PROCEDURE IF EXISTS addConferenceDetailRecord;
 CREATE PROCEDURE addConferenceDetailRecord(	IN in_sid VARCHAR(34),


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates a database index for table restcomm_sms_messages, column smpp_message_id in the SQL script responsible for creating the database.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes BS-231

**Special notes for your reviewer**:
none
