### PR TITLE
BS-288 fixed inbound call is marked as canceled when creating bridge …

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
@@ -1278,7 +1278,7 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                             removeDialBranch(message, sender);
                             checkDialBranch(message, sender, action);
                         }
-                        else {
+                        else if (liveCallModification){
                             //case for LCM testTerminateDialForkCallWhileRinging_LCM_to_dial_branches
                             callState = event.state();
                     }


### PR DESCRIPTION
…in forking call

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
RCML:
<Response>
<Dial><Client>alice</Dial></Client>
<Dial><Client>bob</Dial></Client>
</Response>

1/ Call to the application above.
2/ bob answer the call.
3/ bob disconnect call
4/ Caller is not received BYE because bob already sent BYE.

Expectation: Caller should receive BYE from RC when bob sends BYE.

Investigation:
There is unknow race condition when RC receive onStateChanged(cancelled, outboudcall), RestComm use this state to mark inbound call state to be canceled. That make RestComm will not sent BYE to a canceled call when bob send BYE.

https://github.com/RestComm/Restcomm-Connect/blob/e6b299776d7e1532bfff5398e56b8ad494322488/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java#L1283

We should check if this is from LCM before marking this to canceled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://telestax.atlassian.net/browse/BS-288
**Special notes for your reviewer**:
This issue just happen on customer's environment.