### PR TITLE
bs-264 completed statusCallBack sent for failed call

### DIFF
--- a/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
@@ -1474,6 +1474,10 @@ public final class Call extends RestcommUntypedActor implements TransitionEndLis
                 outgoingCallRecord = outgoingCallRecord.setStatus(external.name());
                 recordsDao.updateCallDetailRecord(outgoingCallRecord);
             }
+
+            if(isOutbound()){
+                executeStatusCallback(CallbackState.COMPLETED, true);
+            }
         }
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
Call Flow:
1/ Caller call to RVD application
2/ RVD Dial verb with status call back call to callee
3/ Callee respond 480 to the call.

Expectation: Even this call is failed, but completed status call back should be sent out.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://telestax.atlassian.net/browse/BS-264
**Special notes for your reviewer**:
