### PR TITLE
bs-357 RC with XMS, after Dial verb failed with 486 BUSY, there is Pl…

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
@@ -911,7 +911,8 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
             }
 
             if (msStopingRingTone) {
-                msStopingRingTone = !(((MediaGroupResponse) message).get() instanceof CollectedResult);
+                Object data =  ((MediaGroupResponse) message).get();
+                msStopingRingTone = !((data instanceof CollectedResult) || (data instanceof String && data.toString().equalsIgnoreCase("PLAY_COMPLETED"))) ;
             }
         } else {
             fsm.transition(message, hangingUp);


### PR DESCRIPTION
…ay/Say verb. After finish playing pay/say verb, RC does not execute next verb.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
RC is integrated with XMS.
RCML:
```
<Response>
<Say>Welcome to Telestax Restcom Visual Designer Demo</Say>
<Dial>
<Client>alice</Client>
</Dial>
<Play>
/restcomm-rvd/services/projects/APb70c33bf0b6748f09eaec97030af36f3/wavs/sorry.wav
</Play>
<Dial>
<Client>anhnguyen</Client>
</Dial>
</Response>
```
1/ Caller call to RVD application
2/ Caller hear say verb
3/ RC send INVITE to alice
4/ Alice respond 486 BUSY here.
5/ RC execute Play verb, Caller can hear play verb.
6/ anhnguyen client does not receive any INVITE
7/ Caller does not hear any thing and RC also does not send BYE to stop call.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://telestax.atlassian.net/browse/BS-357
**Special notes for your reviewer**:
