### PR TITLE
BS-282 imcomming call duration should not contain Ringing duration of…

### DIFF
--- a/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
+++ b/restcomm/restcomm.interpreter/src/main/java/org/restcomm/connect/interpreter/VoiceInterpreter.java
@@ -3363,10 +3363,17 @@ public class VoiceInterpreter extends BaseVoiceInterpreter {
                 final CallDetailRecordsDao records = storage.getCallDetailRecordsDao();
                 callRecord = records.getCallDetailRecord(callRecord.getSid());
                 callRecord = callRecord.setStatus(callState.toString());
+
+                int outboundCallRingDuration = 0;
+                if (outboundCallInfo != null) {
+                    outboundCallRingDuration = records.getCallDetailRecord(outboundCallInfo.sid()).getRingDuration();
+                }
+
                 final DateTime end = DateTime.now();
                 callRecord = callRecord.setEndTime(end);
                 final int seconds = (int) (end.getMillis() - callRecord.getStartTime().getMillis()) / 1000;
-                callRecord = callRecord.setDuration(seconds);
+                // We don't count ringing duration from outbout call to this record.
+                callRecord = callRecord.setDuration(seconds - outboundCallRingDuration);
                 records.updateCallDetailRecord(callRecord);
             }
             if (!dialActionExecuted) {

--- a/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
+++ b/restcomm/restcomm.telephony/src/main/java/org/restcomm/connect/telephony/Call.java
@@ -1852,7 +1852,10 @@ public final class Call extends RestcommUntypedActor implements TransitionEndLis
                 outgoingCallRecord = outgoingCallRecord.setStatus(external.toString());
                 final DateTime now = DateTime.now();
                 outgoingCallRecord = outgoingCallRecord.setEndTime(now);
-                callDuration = (int) ((now.getMillis() - outgoingCallRecord.getStartTime().getMillis()) / 1000);
+                // Calculate call duration when the state is completed.
+                if (external.equals(CallStateChanged.State.COMPLETED)) {
+                    callDuration = (int) ((now.getMillis() - outgoingCallRecord.getStartTime().getMillis()) / 1000);
+                }
                 outgoingCallRecord = outgoingCallRecord.setDuration(callDuration);
                 recordsDao.updateCallDetailRecord(outgoingCallRecord);
                 if(logger.isDebugEnabled()) {

--- a/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialActionTest.java
+++ b/restcomm/restcomm.testsuite/src/test/java/org/restcomm/connect/testsuite/telephony/DialActionTest.java
@@ -689,6 +689,8 @@ public class DialActionTest {
         assertNotNull(dialCallSid);
         JsonObject cdr = RestcommCallsTool.getInstance().getCall(deploymentUrl.toString(), adminAccountSid, adminAuthToken, dialCallSid);
         assertNotNull(cdr);
+        assertTrue(cdr.get("duration").getAsString().equalsIgnoreCase("0")); //Only talk time
+        assertTrue(cdr.get("direction").getAsString().equalsIgnoreCase("outbound-api"));
 
         JsonObject metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
         Map<String, Integer> mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
@@ -772,6 +774,8 @@ public class DialActionTest {
         assertNotNull(dialCallSid);
         JsonObject cdr = RestcommCallsTool.getInstance().getCall(deploymentUrl.toString(), adminAccountSid, adminAuthToken, dialCallSid);
         assertNotNull(cdr);
+        assertTrue(cdr.get("duration").getAsString().equalsIgnoreCase("0")); //Only talk time
+        assertTrue(cdr.get("direction").getAsString().equalsIgnoreCase("outbound-api"));
 
         JsonObject metrics = MonitoringServiceTool.getInstance().getMetrics(deploymentUrl.toString(),adminAccountSid, adminAuthToken);
         Map<String, Integer> mgcpResources = MonitoringServiceTool.getInstance().getMgcpResources(metrics);
@@ -1147,7 +1151,7 @@ public class DialActionTest {
         assertNotNull(dialCdr);
 
         //INBOUND call has no ring_duration since Restcomm will answer imediatelly an incoming call
-        assertTrue(cdr.get("duration").getAsString().equalsIgnoreCase("5")); //Only talk time
+        assertTrue(cdr.get("duration").getAsString().equalsIgnoreCase("3")); //Only talk time
         assertTrue(cdr.get("direction").getAsString().equalsIgnoreCase("inbound"));
 
         assertTrue(dialCdr.get("duration").getAsString().equalsIgnoreCase("3")); //Only talk time


### PR DESCRIPTION
… outbound call

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
Incoming leg rings for 1m while waiting for the outbound leg to answer. We include that 1m on the incoming leg duration, but from Twilio example, it seems they don't do it.
And the biggest problem happens when outgoing leg doesn’t answer, in this case, basically, we charged the incoming leg with a ringing duration for a call that didn’t happen.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://telestax.atlassian.net/browse/BS-282
**Special notes for your reviewer**:
