### PR TITLE
Fix to support self-closing XML elements of SMTP config

### DIFF
--- a/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-utensil.sh
+++ b/restcomm/configuration/config-scripts/as7-config-scripts/restcomm/autoconfig.d/config-utensil.sh
@@ -75,17 +75,17 @@ configSMTP(){
     else
             echo "SMTP_USER $SMTP_USER SMTP_PASSWORD $SMTP_PASSWORD SMTP_HOST $SMTP_HOST"
             sed -i "/<smtp-notify>/ {
-            N; s|<host>.*</host>|<host>${SMTP_HOST}</host>|
-            N; s|<user>.*</user>|<user>${SMTP_USER}</user>|
-            N; s|<password>.*</password>|<password>${SMTP_PASSWORD}</password>|
-            N; s|<port>.*</port>|<port>${SMTP_PORT}</port>|
+            N; s|<host.*>.*|<host>${SMTP_HOST}</host>|
+            N; s|<user.*>.*</user>|<user>${SMTP_USER}</user>|
+            N; s|<password.*>.*</password>|<password>${SMTP_PASSWORD}</password>|
+            N; s|<port.*>.*</port>|<port>${SMTP_PORT}</port>|
             }" $FILE
 
             sed -i "/<smtp-service>/ {
-            N; s|<host>.*</host>|<host>${SMTP_HOST}</host>|
-            N; s|<user>.*</user>|<user>${SMTP_USER}</user>|
-            N; s|<password>.*</password>|<password>${SMTP_PASSWORD}</password>|
-            N; s|<port>.*</port>|<port>${SMTP_PORT}</port>|
+            N; s|<host.*>.*|<host>${SMTP_HOST}</host>|
+            N; s|<user.*>.*|<user>${SMTP_USER}</user>|
+            N; s|<password.*>.*|<password>${SMTP_PASSWORD}</password>|
+            N; s|<port.*>.*|<port>${SMTP_PORT}</port>|
             }" $FILE
     fi
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read the Telestax Open Source Playbook https://docs.google.com/document/d/1RZz2nd2ivCK_rg1vKX9ansgNF6NpK_PZl81GxZ2MSnM/edit?usp=sharing
2. If the PR is unfinished, add a `[WIP]` at the start of the PR title. You can remove it when it's ready to be reviewed.
-->

**What this PR does / why we need it**:
Fixes auto-configuration shell script to support self-closing XML elements from SMTP configuration at `WEB-INF/conf/restcomm.xml`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/RestComm/Restcomm-Connect/issues/2999

**Special notes for your reviewer**:
The new pattern matches the entire line from a given prefix, applicable for both regular or self-closing XML elements.